### PR TITLE
Return `None` from `get_current_workfile` when no workfile is currently opened

### DIFF
--- a/client/ayon_tvpaint/api/pipeline.py
+++ b/client/ayon_tvpaint/api/pipeline.py
@@ -159,7 +159,7 @@ class TVPaintHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
     def work_root(self, session):
         return session["AYON_WORKDIR"]
 
-    def get_current_workfile(self):        
+    def get_current_workfile(self):
         # TVPaint returns a '\' character when no scene is currently opened
         current_workfile = execute_george("tv_GetProjectName")
         if current_workfile == '\\':

--- a/client/ayon_tvpaint/api/pipeline.py
+++ b/client/ayon_tvpaint/api/pipeline.py
@@ -159,8 +159,12 @@ class TVPaintHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
     def work_root(self, session):
         return session["AYON_WORKDIR"]
 
-    def get_current_workfile(self):
-        return execute_george("tv_GetProjectName")
+    def get_current_workfile(self):        
+        # TVPaint returns a '\' character when no scene is currently opened
+        current_workfile = execute_george("tv_GetProjectName")
+        if current_workfile == '\\':
+            return None
+        return current_workfile
 
     def workfile_has_unsaved_changes(self):
         return None


### PR DESCRIPTION
## Changelog Description

Return `None` when no workfile is currently opened. 

## Additional info

Ported from: https://github.com/ynput/OpenPype/pull/6342

## Testing notes:

1. Validate that TVPaint indeeds returns that and that now it returns None due to this change.
