### PR TITLE
Use correct key for workfile templater builder

### DIFF
--- a/server/settings/workfile_builder.py
+++ b/server/settings/workfile_builder.py
@@ -12,7 +12,7 @@ class CustomBuilderTemplate(BaseSettingsModel):
         title="Task types",
         enum_resolver=task_types_enum
     )
-    template_path: MultiplatformPathModel = SettingsField(
+    path: MultiplatformPathModel = SettingsField(
         default_factory=MultiplatformPathModel
     )
 


### PR DESCRIPTION
## Changelog description
Renamed `template_path` to `path` in the settings model to fix workfile template build logic.

# Testing steps
- add preset to `ayon+settings://tvpaint/workfile_builder/custom_templates` something like this:
![image](https://github.com/user-attachments/assets/72f6577a-9d89-4ae5-b17d-71368780b03f)
- enebable: `ayon+settings://tvpaint/workfile_builder/create_first_version`
- create new task corresponding to the preset Task type filtering
- Add tvp template file to corresponding with the preset configuration
- Open TVP at the new task where no workfile ever been created before
- See that new workfile version was automatically created from the template file
