### PR TITLE
Chore: Preparation for farm rendering

### DIFF
--- a/client/ayon_tvpaint/plugins/publish/collect_workfile_data.py
+++ b/client/ayon_tvpaint/plugins/publish/collect_workfile_data.py
@@ -4,6 +4,7 @@ import tempfile
 
 import pyblish.api
 
+from ayon_core.pipeline import PublishError
 from ayon_tvpaint.api.lib import (
     execute_george,
     execute_george_through_file,
@@ -170,6 +171,11 @@ class CollectWorkfileData(pyblish.api.ContextPlugin):
         scene_index = 0
         while True:
             scene_id = execute_george(f"tv_sceneenumid {scene_index}")
+            if scene_id == "none":
+                raise PublishError(
+                    "Current scene was not found in workfile."
+                )
+
             if scene_id == current_scene_id:
                 break
             scene_index += 1
@@ -180,6 +186,11 @@ class CollectWorkfileData(pyblish.api.ContextPlugin):
             clip_id = execute_george(
                 f"tv_clipenumid {current_scene_id} {clip_index}"
             )
+            if clip_id == "none":
+                raise PublishError(
+                    "Current clip was not found in scene."
+                )
+
             if clip_id == current_clip_id:
                 break
             clip_index += 1

--- a/client/ayon_tvpaint/plugins/publish/collect_workfile_data.py
+++ b/client/ayon_tvpaint/plugins/publish/collect_workfile_data.py
@@ -166,6 +166,24 @@ class CollectWorkfileData(pyblish.api.ContextPlugin):
         result = execute_george("tv_markout")
         mark_out_frame, mark_out_state, _ = result.split(" ")
 
+        current_scene_id = execute_george("tv_scenecurrentid")
+        scene_index = 0
+        while True:
+            scene_id = execute_george(f"tv_sceneenumid {scene_index}")
+            if scene_id == current_scene_id:
+                break
+            scene_index += 1
+
+        current_clip_id = execute_george("tv_clipcurrentid")
+        clip_index = 0
+        while True:
+            clip_id = execute_george(
+                f"tv_clipenumid {current_scene_id} {clip_index}"
+            )
+            if clip_id == current_clip_id:
+                break
+            clip_index += 1
+
         scene_data = {
             "currentFile": workfile_path,
             "sceneWidth": width,
@@ -178,7 +196,9 @@ class CollectWorkfileData(pyblish.api.ContextPlugin):
             "sceneMarkOut": int(mark_out_frame),
             "sceneMarkOutState": mark_out_state == "set",
             "sceneStartFrame": int(execute_george("tv_startframe")),
-            "sceneBgColor": self._get_bg_color()
+            "sceneBgColor": self._get_bg_color(),
+            "sceneSceneIdx": scene_index,
+            "sceneClipIdx": clip_index,
         }
         self.log.debug(
             "Scene data: {}".format(json.dumps(scene_data, indent=4))

--- a/client/ayon_tvpaint/plugins/publish/extract_convert_to_exr.py
+++ b/client/ayon_tvpaint/plugins/publish/extract_convert_to_exr.py
@@ -33,6 +33,9 @@ class ExtractConvertToEXR(pyblish.api.InstancePlugin):
     exr_compression = "ZIP"
 
     def process(self, instance):
+        if instance.data.get("farm"):
+            return
+
         repres = instance.data.get("representations")
         if not repres:
             return

--- a/client/ayon_tvpaint/plugins/publish/extract_sequence.py
+++ b/client/ayon_tvpaint/plugins/publish/extract_sequence.py
@@ -37,6 +37,9 @@ class ExtractSequence(pyblish.api.InstancePlugin):
     review_bg = [255, 255, 255, 1.0]
 
     def process(self, instance):
+        if instance.data.get("farm"):
+            return
+
         self.log.info(
             "* Processing instance \"{}\"".format(instance.data["label"])
         )
@@ -380,7 +383,7 @@ class ExtractSequence(pyblish.api.InstancePlugin):
             else:
                 self.log.info((
                     "Source for thumbnail has mode \"{}\" (Expected: RGBA)."
-                    " Can't use thubmanail background color."
+                    " Can't use thumbnail background color."
                 ).format(source_img.mode))
                 source_img.save(thumbnail_filepath)
 


### PR DESCRIPTION
## Changelog Description
Skip extractors if instances have set `farm` to `True` and store more information about scene into context that might be needed for farm processing.

## Testing notes:
1. Nothing shoud change for local publishing.
