### PR TITLE
Chore: Fix product name calculation error

### DIFF
--- a/client/ayon_tvpaint/api/plugin.py
+++ b/client/ayon_tvpaint/api/plugin.py
@@ -60,7 +60,8 @@ class TVPaintCreatorCommon:
         task_entity,
         variant,
         host_name=None,
-        instance=None
+        instance=None,
+        project_entity=None,
     ):
         dynamic_data = self.get_dynamic_data(
             project_name,
@@ -84,7 +85,8 @@ class TVPaintCreatorCommon:
             variant,
             dynamic_data=dynamic_data,
             project_settings=self.project_settings,
-            product_type_filter=self.product_template_product_type
+            product_type_filter=self.product_template_product_type,
+            project_entity=project_entity,
         )
 
 


### PR DESCRIPTION
## Changelog Description
Fix arguments in product name calculation.

## Testing notes:
1. Create package, upload to server and use in bundle.
2. Open publisher.
3. New instances should have correctly calculated product name.
4. Change of context on existing instances should properly fill product name.

Resolves https://github.com/ynput/ayon-tvpaint/issues/2