### PR TITLE
Workfile: Use task level attributes

### DIFF
--- a/client/ayon_tvpaint/api/communication_server.py
+++ b/client/ayon_tvpaint/api/communication_server.py
@@ -880,7 +880,6 @@ class QtCommunicator(BaseCommunicator):
         self.callback_queue.append(main_thread_item)
         if wait:
             return main_thread_item.wait()
-        return
 
     async def async_execute_in_main_thread(self, main_thread_item, wait=True):
         """Add `MainThreadItem` to callback queue and wait for result."""

--- a/client/ayon_tvpaint/api/pipeline.py
+++ b/client/ayon_tvpaint/api/pipeline.py
@@ -23,6 +23,7 @@ from .lib import (
     execute_george,
     execute_george_through_file
 )
+from .communication_server import CommunicationWrapper, MainThreadItem
 
 log = logging.getLogger(__name__)
 
@@ -241,7 +242,12 @@ class TVPaintHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         # Make sure opened workfile has stored correct context
         global_context = get_global_context()
         save_current_workfile_context(global_context)
-        self._set_workfile_attributes()
+        communicator = CommunicationWrapper.communicator
+        if hasattr(communicator, "execute_in_main_thread"):
+            communicator.execute_in_main_thread(
+                MainThreadItem(self._set_workfile_attributes),
+                False
+            )
 
 
 def containerise(


### PR DESCRIPTION
## Changelog Description
Change mark in/out resolution and fps based on attributes set on task entity.

## Additional review information
Mark in is always kept in scene and only Mark out is set based on frame start/end.
Backup workfile is created if resolution change is required as resizing project has undoable/irreversible affect on the scene.

## Testing notes:
1. Create a workfile with wrong mark in/out and resolution. Mark in/out can be changed in timeline. Resolution can be changed with `Project` > `Modify Project...` > `Width` and `Height`.
2. Save.
3. Open the workfile using workfiles tool.
4. It should ask you about wrong resolution, after confirmation backup file is created on disk and resized project is opened. Mark in/out should be set to correct frame range.

Resolves https://github.com/ynput/ayon-tvpaint/issues/33
Resolves https://github.com/ynput/ayon-tvpaint/issues/31