### PR TITLE
Create attributes: Remove help labels

### DIFF
--- a/client/ayon_tvpaint/plugins/create/create_render.py
+++ b/client/ayon_tvpaint/plugins/create/create_render.py
@@ -33,7 +33,6 @@ Todos:
     Add option to extract marked layers and passes as json output format for
         AfterEffects.
 """
-
 import collections
 from typing import Any, Optional, Union
 
@@ -42,7 +41,6 @@ import ayon_api
 from ayon_core.lib import (
     prepare_template_data,
     AbstractAttrDef,
-    UILabelDef,
     UISeparatorDef,
     EnumDef,
     TextDef,
@@ -677,9 +675,6 @@ class CreateRenderPass(TVPaintCreator):
                 label="Render Layer",
                 items=render_layers
             ),
-            UILabelDef(
-                "NOTE: Try to hit refresh if you don't see a Render Layer"
-            ),
             BoolDef(
                 "mark_for_review",
                 label="Review",
@@ -704,9 +699,6 @@ class CreateRenderPass(TVPaintCreator):
                 label="Render Layer",
                 items=render_layers,
                 default=default,
-            ),
-            UILabelDef(
-                "NOTE: Try to hit refresh if you don't see a Render Layer"
             ),
             BoolDef(
                 "mark_for_review",


### PR DESCRIPTION
## Changelog Description
Remove redundant help label from create attibutes.

## Additional review information
Render layers are auto-populated since https://github.com/ynput/ayon-tvpaint/pull/36 so it is not necessary to have the label there.
