### PR TITLE
Create: Fix and enhance product name calculation

### DIFF
--- a/client/ayon_tvpaint/api/plugin.py
+++ b/client/ayon_tvpaint/api/plugin.py
@@ -119,20 +119,6 @@ class TVPaintCreator(Creator, TVPaintCreatorCommon):
         for instance in instances:
             self._remove_instance_from_context(instance)
 
-    def get_dynamic_data(self, *args, **kwargs):
-        # Change folder and name by current workfile context
-        create_context = self.create_context
-        folder_path = create_context.get_current_folder_path()
-        task_name = create_context.get_current_task_name()
-        output = {}
-        if folder_path:
-            folder_name = folder_path.rsplit("/")[-1]
-            output["asset"] = folder_name
-            output["folder"] = {"name": folder_name}
-            if task_name:
-                output["task"] = task_name
-        return output
-
     def get_product_name(self, *args, **kwargs):
         return self._custom_get_product_name(*args, **kwargs)
 

--- a/client/ayon_tvpaint/api/plugin.py
+++ b/client/ayon_tvpaint/api/plugin.py
@@ -63,6 +63,10 @@ class TVPaintCreatorCommon:
         instance=None,
         project_entity=None,
     ):
+        if host_name is None:
+            host_name = self.create_context.host_name
+        if project_entity is None:
+            project_entity = self.create_context.get_current_project_entity()
         dynamic_data = self.get_dynamic_data(
             project_name,
             folder_entity,
@@ -92,6 +96,11 @@ class TVPaintCreatorCommon:
 
 class TVPaintCreator(Creator, TVPaintCreatorCommon):
     settings_category = "tvpaint"
+    _use_current_context = False
+
+    def apply_settings(self, project_settings):
+        create_settings = project_settings["tvpaint"]["create"]
+        self._use_current_context = create_settings["use_current_context"]
 
     def collect_instances(self):
         self._collect_create_instances()
@@ -119,8 +128,16 @@ class TVPaintCreator(Creator, TVPaintCreatorCommon):
         for instance in instances:
             self._remove_instance_from_context(instance)
 
-    def get_product_name(self, *args, **kwargs):
-        return self._custom_get_product_name(*args, **kwargs)
+    def get_product_name(
+        self, project_name, folder_entity, task_entity, *args, **kwargs
+    ):
+        if self._use_current_context:
+            # Use the current context to get project and task
+            folder_entity = self.create_context.get_current_folder_entity()
+            task_entity = self.create_context.get_current_task_entity()
+        return self._custom_get_product_name(
+            project_name, folder_entity, task_entity, *args, **kwargs
+        )
 
     def _store_new_instance(self, new_instance):
         instances_data = self.host.list_instances()

--- a/client/ayon_tvpaint/api/plugin.py
+++ b/client/ayon_tvpaint/api/plugin.py
@@ -53,6 +53,38 @@ class TVPaintCreatorCommon:
             cur_instance_data.update(instance_data)
         self.host.write_instances(cur_instances)
 
+    def _update_instance_context(self, instance: CreatedInstance) -> bool:
+        host_name = self.create_context.host_name
+        project_name = self.create_context.get_current_project_name()
+        folder_path = self.create_context.get_current_folder_path()
+        task_name = self.create_context.get_current_task_name()
+        if (
+            instance["folderPath"] == folder_path
+            and instance["task"] == task_name
+        ):
+            return False
+
+        project_entity = self.create_context.get_current_project_entity()
+        folder_entity = self.create_context.get_folder_entity(
+            folder_path
+        )
+        task_entity = self.create_context.get_task_entity(
+            folder_path, task_name
+        )
+        product_name = self.get_product_name(
+            project_name,
+            folder_entity,
+            task_entity,
+            instance["variant"],
+            host_name,
+            instance,
+            project_entity=project_entity,
+        )
+        instance["folderPath"] = folder_path
+        instance["task"] = task_name
+        instance["productName"] = product_name
+        return True
+
     def _custom_get_product_name(
         self,
         project_name,

--- a/client/ayon_tvpaint/plugins/create/create_render.py
+++ b/client/ayon_tvpaint/plugins/create/create_render.py
@@ -993,7 +993,7 @@ class TVPaintAutoDetectRenderCreator(TVPaintCreator):
             variant = layer_name
             render_pass = render_pass_by_layer_name.get(layer_name)
             if render_pass is not None:
-                if (render_pass["layer_names"]) > 1:
+                if len(render_pass["layer_names"]) > 1:
                     variant = render_pass["variant"]
 
             product_name = creator.get_product_name(

--- a/client/ayon_tvpaint/plugins/create/create_render.py
+++ b/client/ayon_tvpaint/plugins/create/create_render.py
@@ -297,6 +297,15 @@ class CreateRenderlayer(TVPaintCreator):
             )
         ]
 
+    def collect_instances(self):
+        super().collect_instances()
+        if not self._use_current_context:
+            return
+
+        for instance in self.create_context.instances:
+            if instance.creator_identifier == self.identifier:
+                self._update_instance_context(instance)
+
     def update_instances(self, update_list):
         self._update_color_groups()
         self._update_renderpass_groups()
@@ -451,6 +460,8 @@ class CreateRenderPass(TVPaintCreator):
 
             instance = CreatedInstance.from_existing(instance_data, self)
             self._add_instance_to_context(instance)
+            if self._use_current_context:
+                self._update_instance_context(instance)
 
             self._set_layer_name(
                 instance["variant"],

--- a/client/ayon_tvpaint/plugins/create/create_render.py
+++ b/client/ayon_tvpaint/plugins/create/create_render.py
@@ -155,17 +155,10 @@ class CreateRenderlayer(TVPaintCreator):
         host_name,
         instance
     ):
-        dynamic_data = super().get_dynamic_data(
-            project_name,
-            folder_entity,
-            task_entity,
-            variant,
-            host_name,
-            instance
-        )
-        dynamic_data["renderpass"] = self.default_pass_name
-        dynamic_data["renderlayer"] = variant
-        return dynamic_data
+        return {
+            "renderpass": self.default_pass_name,
+            "renderlayer": variant,
+        }
 
     def _get_selected_group_ids(self):
         return {
@@ -1220,17 +1213,10 @@ class TVPaintSceneRenderCreator(TVPaintAutoCreator):
         host_name,
         instance
     ):
-        dynamic_data = super().get_dynamic_data(
-            project_name,
-            folder_entity,
-            task_entity,
-            variant,
-            host_name,
-            instance
-        )
-        dynamic_data["renderpass"] = "{renderpass}"
-        dynamic_data["renderlayer"] = variant
-        return dynamic_data
+        return {
+            "renderpass": "{renderpass}",
+            "renderlayer": variant,
+        }
 
     def _create_new_instance(self):
         create_context = self.create_context

--- a/client/ayon_tvpaint/plugins/create/create_render.py
+++ b/client/ayon_tvpaint/plugins/create/create_render.py
@@ -36,8 +36,6 @@ Todos:
 import collections
 from typing import Any, Optional, Union
 
-import ayon_api
-
 from ayon_core.lib import (
     prepare_template_data,
     AbstractAttrDef,
@@ -1053,10 +1051,11 @@ class TVPaintAutoDetectRenderCreator(TVPaintCreator):
         project_name: str = self.create_context.get_current_project_name()
         folder_path: str = instance_data["folderPath"]
         task_name: str = instance_data["task"]
-        folder_entity: dict[str, Any] = ayon_api.get_folder_by_path(
-            project_name, folder_path)
-        task_entity: dict[str, Any] = ayon_api.get_task_by_name(
-            project_name, folder_entity["id"], task_name
+        folder_entity: dict[str, Any] = self.create_context.get_folder_entity(
+            folder_path
+        )
+        task_entity: dict[str, Any] = self.create_context.get_task_entity(
+            folder_path, task_name
         )
 
         render_layers_by_group_id: dict[int, CreatedInstance] = {}
@@ -1237,13 +1236,9 @@ class TVPaintSceneRenderCreator(TVPaintAutoCreator):
         create_context = self.create_context
         host_name = create_context.host_name
         project_name = create_context.get_current_project_name()
-        folder_path = create_context.get_current_folder_path()
-        task_name = create_context.get_current_task_name()
+        folder_entity = create_context.get_current_folder_entity()
+        task_entity = create_context.get_current_task_entity()
 
-        folder_entity = ayon_api.get_folder_by_path(project_name, folder_path)
-        task_entity = ayon_api.get_task_by_name(
-            project_name, folder_entity["id"], task_name
-        )
         product_name = self.get_product_name(
             project_name,
             folder_entity,
@@ -1252,8 +1247,8 @@ class TVPaintSceneRenderCreator(TVPaintAutoCreator):
             host_name,
         )
         data = {
-            "folderPath": folder_path,
-            "task": task_name,
+            "folderPath": folder_entity["path"],
+            "task": task_entity["name"],
             "variant": self.default_variant,
             "creator_attributes": {
                 "render_pass_name": self.default_pass_name,
@@ -1297,11 +1292,9 @@ class TVPaintSceneRenderCreator(TVPaintAutoCreator):
             existing_name != folder_path
             or existing_instance["task"] != task_name
         ):
-            folder_entity = ayon_api.get_folder_by_path(
-                project_name, folder_path
-            )
-            task_entity = ayon_api.get_task_by_name(
-                project_name, folder_entity["id"], task_name
+            folder_entity = self.create_context.get_folder_entity(folder_path)
+            task_entity = self.create_context.get_task_entity(
+                folder_path, task_name
             )
             product_name = self.get_product_name(
                 project_name,

--- a/client/ayon_tvpaint/plugins/create/create_review.py
+++ b/client/ayon_tvpaint/plugins/create/create_review.py
@@ -26,69 +26,34 @@ class TVPaintReviewCreator(TVPaintAutoCreator):
                 existing_instance = instance
                 break
 
-        create_context = self.create_context
-        host_name = create_context.host_name
-        project_name = create_context.get_current_project_name()
-        folder_path = create_context.get_current_folder_path()
-        task_name = create_context.get_current_task_name()
-
-        existing_folder_path = None
         if existing_instance is not None:
-            existing_folder_path = existing_instance["folderPath"]
+            self._update_instance_context(existing_instance)
+            return
 
-        if existing_instance is None:
-            project_entity = self.create_context.get_current_project_entity()
-            folder_entity = self.create_context.get_folder_entity(
-                folder_path
-            )
-            task_entity = self.create_context.get_task_entity(
-                folder_path, task_name
-            )
-            product_name = self.get_product_name(
-                project_name,
-                folder_entity,
-                task_entity,
-                self.default_variant,
-                host_name,
-                project_entity=project_entity,
-            )
-            data = {
-                "folderPath": folder_path,
-                "task": task_name,
-                "variant": self.default_variant,
-            }
+        project_entity = self.create_context.get_current_project_entity()
+        folder_entity = self.create_context.get_current_folder_entity()
+        task_entity = self.create_context.get_current_task_entity()
+        product_name = self.get_product_name(
+            project_entity["name"],
+            folder_entity,
+            task_entity,
+            self.default_variant,
+            self.create_context.host_name,
+            project_entity=project_entity,
+        )
+        data = {
+            "folderPath": folder_entity["path"],
+            "task": task_entity["name"],
+            "variant": self.default_variant,
+        }
 
-            if not self.active_on_create:
-                data["active"] = False
+        if not self.active_on_create:
+            data["active"] = False
 
-            new_instance = CreatedInstance(
-                self.product_type, product_name, data, self
-            )
-            instances_data = self.host.list_instances()
-            instances_data.append(new_instance.data_to_store())
-            self.host.write_instances(instances_data)
-            self._add_instance_to_context(new_instance)
-
-        elif (
-            existing_folder_path != folder_path
-            or existing_instance["task"] != task_name
-        ):
-            project_entity = self.create_context.get_current_project_entity()
-            folder_entity = self.create_context.get_folder_entity(
-                folder_path
-            )
-            task_entity = self.create_context.get_task_entity(
-                folder_path, task_name
-            )
-            product_name = self.get_product_name(
-                project_name,
-                folder_entity,
-                task_entity,
-                existing_instance["variant"],
-                host_name,
-                existing_instance,
-                project_entity=project_entity,
-            )
-            existing_instance["folderPath"] = folder_path
-            existing_instance["task"] = task_name
-            existing_instance["productName"] = product_name
+        new_instance = CreatedInstance(
+            self.product_type, product_name, data, self
+        )
+        instances_data = self.host.list_instances()
+        instances_data.append(new_instance.data_to_store())
+        self.host.write_instances(instances_data)
+        self._add_instance_to_context(new_instance)

--- a/client/ayon_tvpaint/plugins/create/create_review.py
+++ b/client/ayon_tvpaint/plugins/create/create_review.py
@@ -1,5 +1,3 @@
-import ayon_api
-
 from ayon_core.pipeline import CreatedInstance
 from ayon_tvpaint.api.plugin import TVPaintAutoCreator
 
@@ -39,18 +37,20 @@ class TVPaintReviewCreator(TVPaintAutoCreator):
             existing_folder_path = existing_instance["folderPath"]
 
         if existing_instance is None:
-            folder_entity = ayon_api.get_folder_by_path(
-                project_name, folder_path
+            project_entity = self.create_context.get_current_project_entity()
+            folder_entity = self.create_context.get_folder_entity(
+                folder_path
             )
-            task_entity = ayon_api.get_task_by_name(
-                project_name, folder_entity["id"], task_name
+            task_entity = self.create_context.get_task_entity(
+                folder_path, task_name
             )
             product_name = self.get_product_name(
                 project_name,
                 folder_entity,
                 task_entity,
                 self.default_variant,
-                host_name
+                host_name,
+                project_entity=project_entity,
             )
             data = {
                 "folderPath": folder_path,
@@ -73,11 +73,12 @@ class TVPaintReviewCreator(TVPaintAutoCreator):
             existing_folder_path != folder_path
             or existing_instance["task"] != task_name
         ):
-            folder_entity = ayon_api.get_folder_by_path(
-                project_name, folder_path
+            project_entity = self.create_context.get_current_project_entity()
+            folder_entity = self.create_context.get_folder_entity(
+                folder_path
             )
-            task_entity = ayon_api.get_task_by_name(
-                project_name, folder_entity["id"], task_name
+            task_entity = self.create_context.get_task_entity(
+                folder_path, task_name
             )
             product_name = self.get_product_name(
                 project_name,
@@ -85,7 +86,8 @@ class TVPaintReviewCreator(TVPaintAutoCreator):
                 task_entity,
                 existing_instance["variant"],
                 host_name,
-                existing_instance
+                existing_instance,
+                project_entity=project_entity,
             )
             existing_instance["folderPath"] = folder_path
             existing_instance["task"] = task_name

--- a/client/ayon_tvpaint/plugins/create/create_workfile.py
+++ b/client/ayon_tvpaint/plugins/create/create_workfile.py
@@ -1,5 +1,3 @@
-import ayon_api
-
 from ayon_core.pipeline import CreatedInstance
 from ayon_tvpaint.api.plugin import TVPaintAutoCreator
 
@@ -35,18 +33,20 @@ class TVPaintWorkfileCreator(TVPaintAutoCreator):
             existing_folder_path = existing_instance["folderPath"]
 
         if existing_instance is None:
-            folder_entity = ayon_api.get_folder_by_path(
-                project_name, folder_path
+            project_entity = self.create_context.get_current_project_entity()
+            folder_entity = self.create_context.get_folder_entity(
+                folder_path
             )
-            task_entity = ayon_api.get_task_by_name(
-                project_name, folder_entity["id"], task_name
+            task_entity = self.create_context.get_task_entity(
+                folder_path, task_name
             )
             product_name = self.get_product_name(
                 project_name,
                 folder_entity,
                 task_entity,
                 self.default_variant,
-                host_name
+                host_name,
+                project_entity=project_entity,
             )
             data = {
                 "folderPath": folder_path,
@@ -66,11 +66,12 @@ class TVPaintWorkfileCreator(TVPaintAutoCreator):
             existing_folder_path != folder_path
             or existing_instance["task"] != task_name
         ):
-            folder_entity = ayon_api.get_folder_by_path(
-                project_name, folder_path
+            project_entity = self.create_context.get_current_project_entity()
+            folder_entity = self.create_context.get_folder_entity(
+                folder_path
             )
-            task_entity = ayon_api.get_task_by_name(
-                project_name, folder_entity["id"], task_name
+            task_entity = self.create_context.get_task_entity(
+                folder_path, task_name
             )
             product_name = self.get_product_name(
                 project_name,
@@ -78,7 +79,8 @@ class TVPaintWorkfileCreator(TVPaintAutoCreator):
                 task_entity,
                 existing_instance["variant"],
                 host_name,
-                existing_instance
+                existing_instance,
+                project_entity=project_entity,
             )
             existing_instance["folderPath"] = folder_path
             existing_instance["task"] = task_name

--- a/client/ayon_tvpaint/plugins/create/create_workfile.py
+++ b/client/ayon_tvpaint/plugins/create/create_workfile.py
@@ -22,66 +22,31 @@ class TVPaintWorkfileCreator(TVPaintAutoCreator):
                 existing_instance = instance
                 break
 
-        create_context = self.create_context
-        host_name = create_context.host_name
-        project_name = create_context.get_current_project_name()
-        folder_path = create_context.get_current_folder_path()
-        task_name = create_context.get_current_task_name()
-
-        existing_folder_path = None
         if existing_instance is not None:
-            existing_folder_path = existing_instance["folderPath"]
+            self._update_instance_context(existing_instance)
+            return
 
-        if existing_instance is None:
-            project_entity = self.create_context.get_current_project_entity()
-            folder_entity = self.create_context.get_folder_entity(
-                folder_path
-            )
-            task_entity = self.create_context.get_task_entity(
-                folder_path, task_name
-            )
-            product_name = self.get_product_name(
-                project_name,
-                folder_entity,
-                task_entity,
-                self.default_variant,
-                host_name,
-                project_entity=project_entity,
-            )
-            data = {
-                "folderPath": folder_path,
-                "task": task_name,
-                "variant": self.default_variant
-            }
+        project_entity = self.create_context.get_current_project_entity()
+        folder_entity = self.create_context.get_current_folder_entity()
+        task_entity = self.create_context.get_current_task_entity()
+        product_name = self.get_product_name(
+            project_entity["name"],
+            folder_entity,
+            task_entity,
+            self.default_variant,
+            self.create_context.host_name,
+            project_entity=project_entity,
+        )
+        data = {
+            "folderPath": folder_entity["path"],
+            "task": task_entity["name"],
+            "variant": self.default_variant
+        }
 
-            new_instance = CreatedInstance(
-                self.product_type, product_name, data, self
-            )
-            instances_data = self.host.list_instances()
-            instances_data.append(new_instance.data_to_store())
-            self.host.write_instances(instances_data)
-            self._add_instance_to_context(new_instance)
-
-        elif (
-            existing_folder_path != folder_path
-            or existing_instance["task"] != task_name
-        ):
-            project_entity = self.create_context.get_current_project_entity()
-            folder_entity = self.create_context.get_folder_entity(
-                folder_path
-            )
-            task_entity = self.create_context.get_task_entity(
-                folder_path, task_name
-            )
-            product_name = self.get_product_name(
-                project_name,
-                folder_entity,
-                task_entity,
-                existing_instance["variant"],
-                host_name,
-                existing_instance,
-                project_entity=project_entity,
-            )
-            existing_instance["folderPath"] = folder_path
-            existing_instance["task"] = task_name
-            existing_instance["productName"] = product_name
+        new_instance = CreatedInstance(
+            self.product_type, product_name, data, self
+        )
+        instances_data = self.host.list_instances()
+        instances_data.append(new_instance.data_to_store())
+        self.host.write_instances(instances_data)
+        self._add_instance_to_context(new_instance)

--- a/server/settings/create_plugins.py
+++ b/server/settings/create_plugins.py
@@ -105,6 +105,10 @@ class AutoDetectCreateRenderModel(BaseSettingsModel):
 
 
 class CreatePluginsModel(BaseSettingsModel):
+    use_current_context: bool = SettingsField(
+        True,
+        title="Force to use current context",
+    )
     create_workfile: CreateWorkfileModel = SettingsField(
         default_factory=CreateWorkfileModel,
         title="Create Workfile"
@@ -132,6 +136,7 @@ class CreatePluginsModel(BaseSettingsModel):
 
 
 DEFAULT_CREATE_SETTINGS = {
+    "use_current_context": True,
     "create_workfile": {
         "enabled": True,
         "default_variant": "Main",


### PR DESCRIPTION
## Changelog Description
Cleaned up create code a little, use new methods available on create context and do not auto-fix current context unless it is set in settings.

## Additional review information
Use helper functions on create context to fetch project, folder and task entities to enhance speed a little. Avoid auto-fixing product name data which lead to invalid data for product name template, instead was added option to use current context on instances to auto-populate the context of instance and the product name. Added settings to force use current context which also updates context of instances on restart if necessary -> enabled by default.

## Testing notes:
1. Make sure product name template for TVPaint contains task key with subkey (e.g. `{Task[name]}`).
2. All creators do work, especially AutoDetect create plugin.
3. If force use current context it is not possible to change context in publish tool and if the file is saved to different context the instances are updated to the new context automatically.