### PR TITLE
EXR merge: Fix merging

### DIFF
--- a/client/ayon_tvpaint/plugins/publish/extract_convert_to_exr.py
+++ b/client/ayon_tvpaint/plugins/publish/extract_convert_to_exr.py
@@ -216,8 +216,9 @@ class ExtractConvertToEXR(pyblish.api.ContextPlugin):
                 channel_names = [f"{product_name}{ch_n}" for ch_n in "RGBA"]
                 args.extend([
                     "-i", path,
-                    "--ch", ",".join(channel_names),
+                    "--chnames", ",".join(channel_names),
                     "--colorconvert", "sRGB", "linear",
+                    "--chappend",
                 ])
 
             output_arg = "-o"

--- a/client/ayon_tvpaint/plugins/publish/extract_convert_to_exr.py
+++ b/client/ayon_tvpaint/plugins/publish/extract_convert_to_exr.py
@@ -16,7 +16,7 @@ from ayon_core.lib import (
     ToolNotFoundError,
     run_subprocess,
 )
-from ayon_core.pipeline import KnownPublishError
+from ayon_core.pipeline import PublishError
 
 
 class ExtractConvertToEXR(pyblish.api.ContextPlugin):
@@ -76,7 +76,7 @@ class ExtractConvertToEXR(pyblish.api.ContextPlugin):
         except ToolNotFoundError:
             # Raise an exception when oiiotool is not available
             # - this can currently happen on MacOS machines
-            raise KnownPublishError(
+            raise PublishError(
                 "OpenImageIO tool is not available on this machine."
             )
 

--- a/client/ayon_tvpaint/plugins/publish/extract_convert_to_exr.py
+++ b/client/ayon_tvpaint/plugins/publish/extract_convert_to_exr.py
@@ -44,10 +44,13 @@ class ExtractConvertToEXR(pyblish.api.ContextPlugin):
             if instance.data.get("publish") is False:
                 continue
 
-            if (
-                instance.data["family"] != "render"
-                or instance.data.get("farm")
-            ):
+            if instance.data["family"] != "render":
+                continue
+
+            if instance.data.get("farm"):
+                self.log.debug(
+                    "Skipping instance, is marked for farm rendering."
+                )
                 continue
 
             repres = instance.data.get("representations") or []
@@ -60,6 +63,7 @@ class ExtractConvertToEXR(pyblish.api.ContextPlugin):
                 None
             )
             if not src_repre:
+                self.log.debug("Skipping instance, no PNG representation.")
                 continue
 
             creator_identifier = instance.data.get("creator_identifier")

--- a/client/ayon_tvpaint/plugins/publish/extract_convert_to_exr.py
+++ b/client/ayon_tvpaint/plugins/publish/extract_convert_to_exr.py
@@ -213,7 +213,7 @@ class ExtractConvertToEXR(pyblish.api.ContextPlugin):
                 pass_staging_dir = pass_repre["stagingDir"]
                 path = os.path.join(pass_staging_dir, pass_filename)
                 # Add the render pass representation
-                channel_names = [f"{product_name}{ch_n}" for ch_n in "RGBA"]
+                channel_names = [f"{product_name}.{ch_n}" for ch_n in "RGBA"]
                 args.extend([
                     "-i", path,
                     "--chnames", ",".join(channel_names),

--- a/client/ayon_tvpaint/plugins/publish/extract_convert_to_exr.py
+++ b/client/ayon_tvpaint/plugins/publish/extract_convert_to_exr.py
@@ -89,11 +89,11 @@ class ExtractConvertToEXR(pyblish.api.ContextPlugin):
         else:
             for item in render_layer_items + render_pass_items:
                 instance, src_repre = item
-                self._simple_exc_conversion(
+                self._simple_exr_conversion(
                     instance, src_repre, base_oiio_args
                 )
 
-    def _simple_exc_conversion(self, instance, repre, base_oiio_args):
+    def _simple_exr_conversion(self, instance, repre, base_oiio_args):
         repres = instance.data["representations"]
 
         src_filepaths = set()

--- a/client/ayon_tvpaint/plugins/publish/extract_convert_to_exr.py
+++ b/client/ayon_tvpaint/plugins/publish/extract_convert_to_exr.py
@@ -33,7 +33,7 @@ class ExtractConvertToEXR(pyblish.api.ContextPlugin):
     replace_pngs = True
     # EXR compression
     exr_compression = "ZIP"
-    multilayer_exr = False
+    multichannel_exr = False
     auto_trim = True
 
     def process(self, context):
@@ -80,8 +80,8 @@ class ExtractConvertToEXR(pyblish.api.ContextPlugin):
                 "OpenImageIO tool is not available on this machine."
             )
 
-        if self.multilayer_exr:
-            self._multilayer_exr_conversion(
+        if self.multichannel_exr:
+            self._multichannel_exr_conversion(
                 render_layer_items,
                 render_pass_items,
                 base_oiio_args
@@ -136,7 +136,7 @@ class ExtractConvertToEXR(pyblish.api.ContextPlugin):
             for filepath in src_filepaths:
                 instance.context.data["cleanupFullPaths"].append(filepath)
 
-    def _multilayer_exr_conversion(
+    def _multichannel_exr_conversion(
         self,
         render_layer_items,
         render_pass_items,

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,8 +1,12 @@
-from typing import Type
+from typing import Type, Any
 
 from ayon_server.addons import BaseServerAddon
 
-from .settings import TvpaintSettings, DEFAULT_VALUES
+from .settings import (
+    convert_settings_overrides,
+    TvpaintSettings,
+    DEFAULT_VALUES,
+)
 
 
 class TvpaintAddon(BaseServerAddon):
@@ -11,3 +15,14 @@ class TvpaintAddon(BaseServerAddon):
     async def get_default_settings(self):
         settings_model_cls = self.get_settings_model()
         return settings_model_cls(**DEFAULT_VALUES)
+
+    async def convert_settings_overrides(
+        self,
+        source_version: str,
+        overrides: dict[str, Any],
+    ) -> dict[str, Any]:
+        await convert_settings_overrides(source_version, overrides)
+        # Use super conversion
+        return await super().convert_settings_overrides(
+            source_version, overrides
+        )

--- a/server/settings/__init__.py
+++ b/server/settings/__init__.py
@@ -2,9 +2,12 @@ from .main import (
     TvpaintSettings,
     DEFAULT_VALUES,
 )
+from .conversion import convert_settings_overrides
 
 
 __all__ = (
     "TvpaintSettings",
     "DEFAULT_VALUES",
+
+    "convert_settings_overrides",
 )

--- a/server/settings/conversion.py
+++ b/server/settings/conversion.py
@@ -1,0 +1,25 @@
+from typing import Any
+
+
+async def _convert_multilayer_0_3_8(
+    overrides: dict[str, Any],
+):
+    values = overrides
+    for key in (
+        "publish",
+        "ExtractConvertToEXR",
+    ):
+        if key not in values:
+            return
+        values = values[key]
+
+    if "multilayer_exr" in values:
+        values["multichannel_exr"] = values.pop("multilayer_exr")
+
+
+async def convert_settings_overrides(
+    source_version: str,
+    overrides: dict[str, Any],
+) -> dict[str, Any]:
+    await _convert_multilayer_0_3_8(overrides)
+    return overrides

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -56,9 +56,9 @@ class ExtractConvertToEXRModel(BaseSettingsModel):
         enum_resolver=compression_enum,
         title="EXR Compression"
     )
-    multilayer_exr: bool = SettingsField(
+    multichannel_exr: bool = SettingsField(
         False,
-        title="Create multilayer EXR",
+        title="Create multichannel EXR",
         description="Merge render passes into a render layer EXR files",
     )
 


### PR DESCRIPTION
## Changelog Description
The logic that should merge render passes is actually merging them.

## Additional review information
The logic to merge exrs did only override each other rgb, and probably did not load renderpasses because it used `--ch` argment instead of `--chnames`. Changed `multilayer` to `multichannel` in settings to match what it is.

## Testing notes:
1. Enable exr extraction `ayon+settings://tvpaint/publish/ExtractConvertToEXR` .
2. Enable multichannel exr `ayon+settings://tvpaint/publish/ExtractConvertToEXR/multichannel_exr` .
3. Render TVPaint scene.
4. Rendered exr representation contains all render passes.
