### PR TITLE
EXR export: Do not convert to linear

### DIFF
--- a/client/ayon_tvpaint/plugins/publish/extract_convert_to_exr.py
+++ b/client/ayon_tvpaint/plugins/publish/extract_convert_to_exr.py
@@ -118,7 +118,6 @@ class ExtractConvertToEXR(pyblish.api.ContextPlugin):
             args = copy.deepcopy(base_oiio_args)
             args.extend([
                 src_filepath,
-                "--colorconvert", "sRGB", "linear",
                 "--compression", self.exr_compression,
                 output_arg, dst_filepath
             ])

--- a/client/ayon_tvpaint/plugins/publish/extract_convert_to_exr.py
+++ b/client/ayon_tvpaint/plugins/publish/extract_convert_to_exr.py
@@ -229,6 +229,7 @@ class ExtractConvertToEXR(pyblish.api.ContextPlugin):
 
             args.extend([
                 "--compression", self.exr_compression,
+                "-d", "uint8",
                 output_arg, dst_path,
             ])
             self.log.debug("Running oiiotool with args: %s", args)

--- a/client/ayon_tvpaint/plugins/publish/extract_convert_to_exr.py
+++ b/client/ayon_tvpaint/plugins/publish/extract_convert_to_exr.py
@@ -119,6 +119,7 @@ class ExtractConvertToEXR(pyblish.api.ContextPlugin):
             args.extend([
                 src_filepath,
                 "--compression", self.exr_compression,
+                "-d", "uint8",
                 output_arg, dst_filepath
             ])
             run_subprocess(args)

--- a/client/ayon_tvpaint/plugins/publish/extract_convert_to_exr.py
+++ b/client/ayon_tvpaint/plugins/publish/extract_convert_to_exr.py
@@ -204,7 +204,6 @@ class ExtractConvertToEXR(pyblish.api.ContextPlugin):
             args.extend([
                 "-i", src_beauty_path,
                 "--ch", "R,G,B,A",
-                "--colorconvert", "sRGB", "linear",
             ])
 
             for (render_pass_instance, pass_repre) in render_pass_items:
@@ -221,7 +220,6 @@ class ExtractConvertToEXR(pyblish.api.ContextPlugin):
                 args.extend([
                     "-i", path,
                     "--chnames", ",".join(channel_names),
-                    "--colorconvert", "sRGB", "linear",
                     "--chappend",
                 ])
 


### PR DESCRIPTION
## Changelog Description
Keep the exrs in sRGB.

## Testing notes:
1. Output exrs won't be in linear but in sRGB.

Resolves https://github.com/ynput/ayon-tvpaint/issues/48