### PR TITLE
Autocreate: Fix keys used in layer name template

### DIFF
--- a/client/ayon_tvpaint/plugins/create/create_render.py
+++ b/client/ayon_tvpaint/plugins/create/create_render.py
@@ -1092,11 +1092,14 @@ class TVPaintAutoDetectRenderCreator(TVPaintCreator):
             fake_variant = "___variant___"
             try:
                 name_regex = template.format(
-                    layer_id=fake_layer,
-                    group_id=fake_group,
+                    layer_index=fake_layer,
+                    group_index=fake_group,
                     variant=fake_variant,
                 )
             except Exception:
+                self.log.error(
+                    "Failed to fill name regex template.", exc_info=True
+                )
                 name_regex = ""
 
             for src, regex in (


### PR DESCRIPTION
## Changelog Description
Fix which keys are used in layer name templates.

## Testing notes:
1. Autocreate does correctly "guess" what is variant from layer name.
