### PR TITLE
Create: Use kwargs to call product name functions

### DIFF
--- a/client/ayon_tvpaint/api/plugin.py
+++ b/client/ayon_tvpaint/api/plugin.py
@@ -72,12 +72,12 @@ class TVPaintCreatorCommon:
             folder_path, task_name
         )
         product_name = self.get_product_name(
-            project_name,
-            folder_entity,
-            task_entity,
-            instance["variant"],
-            host_name,
-            instance,
+            project_name=project_name,
+            folder_entity=folder_entity,
+            task_entity=task_entity,
+            variant=instance["variant"],
+            host_name=host_name,
+            instance=instance,
             project_entity=project_entity,
         )
         instance["folderPath"] = folder_path
@@ -113,12 +113,12 @@ class TVPaintCreatorCommon:
             task_type = task_entity["taskType"]
 
         return get_product_name(
-            project_name,
-            task_name,
-            task_type,
-            host_name,
-            self.product_type,
-            variant,
+            project_name=project_name,
+            task_name=task_name,
+            task_type=task_type,
+            host_name=host_name,
+            product_type=self.product_type,
+            variant=variant,
             dynamic_data=dynamic_data,
             project_settings=self.project_settings,
             product_type_filter=self.product_template_product_type,

--- a/client/ayon_tvpaint/plugins/create/create_render.py
+++ b/client/ayon_tvpaint/plugins/create/create_render.py
@@ -184,11 +184,11 @@ class CreateRenderlayer(TVPaintCreator):
             project_entity = self.create_context.get_current_project_entity()
 
             product_name = self.get_product_name(
-                project_name,
-                folder_entity,
-                task_entity,
-                variant=group_name,
+                project_name=project_name,
                 project_entity=project_entity,
+                folder_entity=folder_entity,
+                task_entity=task_entity,
+                variant=group_name,
             )
 
             instance_data["folderPath"] = folder_entity["path"]
@@ -598,11 +598,11 @@ class CreateRenderPass(TVPaintCreator):
             project_entity = self.create_context.get_current_project_entity()
 
             product_name = self.get_product_name(
-                project_name,
-                folder_entity,
-                task_entity,
-                variant=instance_data["variant"],
+                project_name=project_name,
                 project_entity=project_entity,
+                folder_entity=folder_entity,
+                task_entity=task_entity,
+                variant=instance_data["variant"],
             )
 
             instance_data["folderPath"] = folder_entity["path"]
@@ -1075,10 +1075,10 @@ class TVPaintAutoDetectRenderCreator(TVPaintCreator):
             self.create_context.creators[CreateRenderlayer.identifier]
         )
         product_name: str = creator.get_product_name(
-            project_entity["name"],
-            folder_entity,
-            task_entity,
-            variant,
+            project_name=project_entity["name"],
+            folder_entity=folder_entity,
+            task_entity=task_entity,
+            variant=variant,
             host_name=self.create_context.host_name,
             project_entity=project_entity,
         )
@@ -1164,10 +1164,10 @@ class TVPaintAutoDetectRenderCreator(TVPaintCreator):
                 variant = layer_name
 
             product_name = creator.get_product_name(
-                project_entity["name"],
-                folder_entity,
-                task_entity,
-                variant,
+                project_name=project_entity["name"],
+                folder_entity=folder_entity,
+                task_entity=task_entity,
+                variant=variant,
                 host_name=self.create_context.host_name,
                 instance=render_pass,
                 project_entity=project_entity,
@@ -1407,11 +1407,11 @@ class TVPaintSceneRenderCreator(TVPaintAutoCreator):
         task_entity = create_context.get_current_task_entity()
 
         product_name = self.get_product_name(
-            project_name,
-            folder_entity,
-            task_entity,
-            self.default_variant,
-            host_name,
+            project_name=project_name,
+            folder_entity=folder_entity,
+            task_entity=task_entity,
+            variant=self.default_variant,
+            host_name=host_name,
         )
         data = {
             "folderPath": folder_entity["path"],
@@ -1464,12 +1464,12 @@ class TVPaintSceneRenderCreator(TVPaintAutoCreator):
                 folder_path, task_name
             )
             product_name = self.get_product_name(
-                project_name,
-                folder_entity,
-                task_entity,
-                existing_instance["variant"],
-                host_name,
-                existing_instance
+                project_name=project_name,
+                folder_entity=folder_entity,
+                task_entity=task_entity,
+                variant=existing_instance["variant"],
+                host_name=host_name,
+                instance=existing_instance,
             )
             existing_instance["folderPath"] = folder_path
             existing_instance["task"] = task_name

--- a/client/ayon_tvpaint/plugins/create/create_review.py
+++ b/client/ayon_tvpaint/plugins/create/create_review.py
@@ -34,11 +34,11 @@ class TVPaintReviewCreator(TVPaintAutoCreator):
         folder_entity = self.create_context.get_current_folder_entity()
         task_entity = self.create_context.get_current_task_entity()
         product_name = self.get_product_name(
-            project_entity["name"],
-            folder_entity,
-            task_entity,
-            self.default_variant,
-            self.create_context.host_name,
+            project_name=project_entity["name"],
+            folder_entity=folder_entity,
+            task_entity=task_entity,
+            variant=self.default_variant,
+            host_name=self.create_context.host_name,
             project_entity=project_entity,
         )
         data = {

--- a/client/ayon_tvpaint/plugins/create/create_workfile.py
+++ b/client/ayon_tvpaint/plugins/create/create_workfile.py
@@ -30,11 +30,11 @@ class TVPaintWorkfileCreator(TVPaintAutoCreator):
         folder_entity = self.create_context.get_current_folder_entity()
         task_entity = self.create_context.get_current_task_entity()
         product_name = self.get_product_name(
-            project_entity["name"],
-            folder_entity,
-            task_entity,
-            self.default_variant,
-            self.create_context.host_name,
+            project_name=project_entity["name"],
+            folder_entity=folder_entity,
+            task_entity=task_entity,
+            variant=self.default_variant,
+            host_name=self.create_context.host_name,
             project_entity=project_entity,
         )
         data = {


### PR DESCRIPTION
## Changelog Description
Use kwargs to call product name functions and use cached data to call them if possible.

## Additional review information
This is preparation for future change in `get_product_name` functionality and update of already added change in `get_product_name` method.

## Testing notes:
1. Product names are calculated correctly.
