### PR TITLE
Mulatilayer exr: Attribute definitions fixes

### DIFF
--- a/client/ayon_tvpaint/plugins/publish/extract_convert_to_exr.py
+++ b/client/ayon_tvpaint/plugins/publish/extract_convert_to_exr.py
@@ -124,6 +124,9 @@ class CollectExrUserOptions(
             .get(cls.__name__, {})
             .get("convert_to_exr")
         )
+        if current_value is None:
+            current_value = default
+
         if (
             current_value == "multichannel_exr"
             and "keep_passes" in cls.user_overrides


### PR DESCRIPTION
## Changelog Description
Correct handling of keep passes when default value of multilayer exrs is used.

## Additional review information
The issue is the same as https://github.com/ynput/ayon-harmony/pull/83 is solving.

## Testing notes:
1. Set `ayon+settings://tvpaint/publish/ExtractConvertToEXR/multichannel_exr` `Create multichannel EXR` to enabled (this way you are forcing to default state to be enabled).
2. Set `Keep render passes` to be in `User overrides` (same Settings).
3. Launch TVPaint.
4. Open `Context` of Publisher UI, `Keep render passes` toggle should be there even if you will hit Refresh button.