### PR TITLE
Chore: Product name signatures

### DIFF
--- a/client/ayon_tvpaint/api/plugin.py
+++ b/client/ayon_tvpaint/api/plugin.py
@@ -116,7 +116,9 @@ class TVPaintCreatorCommon:
             product_type=product_type,
         )
         for kwarg in ("product_type", "project_entity"):
-            if not is_func_signature_supported(dyn_data_kwargs):
+            if not is_func_signature_supported(
+                self.get_dynamic_data, **dyn_data_kwargs
+            ):
                 dyn_data_kwargs.pop(kwarg)
         dynamic_data = self.get_dynamic_data(**dyn_data_kwargs)
 

--- a/client/ayon_tvpaint/api/plugin.py
+++ b/client/ayon_tvpaint/api/plugin.py
@@ -1,5 +1,7 @@
 import re
+from typing import Optional, Any
 
+from ayon_core.lib import is_func_signature_supported
 from ayon_core.pipeline import LoaderPlugin
 from ayon_core.pipeline.create import (
     CreatedInstance,
@@ -87,26 +89,39 @@ class TVPaintCreatorCommon:
 
     def _custom_get_product_name(
         self,
-        project_name,
-        folder_entity,
-        task_entity,
-        variant,
-        host_name=None,
-        instance=None,
-        project_entity=None,
+        project_name: str,
+        folder_entity: Optional[dict[str, Any]],
+        task_entity: Optional[dict[str, Any]],
+        variant: str,
+        host_name: Optional[str],
+        instance: Optional[CreatedInstance],
+        project_entity: Optional[dict[str, Any]],
+        product_type: Optional[str],
     ):
         if host_name is None:
             host_name = self.create_context.host_name
         if project_entity is None:
             project_entity = self.create_context.get_current_project_entity()
-        dynamic_data = self.get_dynamic_data(
-            project_name,
-            folder_entity,
-            task_entity,
-            variant,
-            host_name,
-            instance
+
+        if not product_type:
+            product_type = self.product_base_type
+        # NOTE this is a workaround for backwards and forwards compatibility
+        #   of 'get_dynamic_data' signature
+        dyn_data_kwargs = dict(
+            project_name=project_name,
+            folder_entity=folder_entity,
+            task_entity=task_entity,
+            variant=variant,
+            host_name=host_name,
+            instance=instance,
+            project_entity=project_entity,
+            product_type=product_type,
         )
+        for kwarg in ("product_type", "project_entity"):
+            if not is_func_signature_supported(dyn_data_kwargs):
+                dyn_data_kwargs.pop(kwarg)
+        dynamic_data = self.get_dynamic_data(**dyn_data_kwargs)
+
         task_name = task_type = None
         if task_entity:
             task_name = task_entity["name"]
@@ -118,6 +133,7 @@ class TVPaintCreatorCommon:
             get_product_name_kwargs.update({
                 "folder_entity": folder_entity,
                 "task_entity": task_entity,
+                "product_type": product_type,
                 "product_base_type": self.product_base_type,
                 "product_base_type_filter": (
                     self.product_template_product_type
@@ -125,6 +141,7 @@ class TVPaintCreatorCommon:
             })
         else:
             get_product_name_kwargs.update({
+                "product_type": self.product_base_type,
                 "task_name": task_name,
                 "task_type": task_type,
                 "product_type_filter": self.product_template_product_type,
@@ -133,7 +150,6 @@ class TVPaintCreatorCommon:
         return get_product_name(
             project_name=project_name,
             host_name=host_name,
-            product_type=self.product_type,
             variant=variant,
             dynamic_data=dynamic_data,
             project_settings=self.project_settings,
@@ -177,14 +193,29 @@ class TVPaintCreator(Creator, TVPaintCreatorCommon):
             self._remove_instance_from_context(instance)
 
     def get_product_name(
-        self, project_name, folder_entity, task_entity, *args, **kwargs
+        self,
+        project_name,
+        folder_entity,
+        task_entity,
+        variant,
+        host_name=None,
+        instance=None,
+        project_entity=None,
+        product_type=None,
     ):
         if self._use_current_context:
             # Use the current context to get project and task
             folder_entity = self.create_context.get_current_folder_entity()
             task_entity = self.create_context.get_current_task_entity()
         return self._custom_get_product_name(
-            project_name, folder_entity, task_entity, *args, **kwargs
+            project_name=project_name,
+            folder_entity=folder_entity,
+            task_entity=task_entity,
+            host_name=host_name,
+            variant=variant,
+            instance=instance,
+            project_entity=project_entity,
+            product_type=product_type,
         )
 
     def _store_new_instance(self, new_instance):
@@ -203,8 +234,27 @@ class TVPaintAutoCreator(AutoCreator, TVPaintCreatorCommon):
     def update_instances(self, update_list):
         self._update_create_instances(update_list)
 
-    def get_product_name(self, *args, **kwargs):
-        return self._custom_get_product_name(*args, **kwargs)
+    def get_product_name(
+        self,
+        project_name,
+        folder_entity,
+        task_entity,
+        variant,
+        host_name=None,
+        instance=None,
+        project_entity=None,
+        product_type=None,
+    ):
+        return self._custom_get_product_name(
+            project_name=project_name,
+            folder_entity=folder_entity,
+            task_entity=task_entity,
+            variant=variant,
+            host_name=host_name,
+            instance=instance,
+            project_entity=project_entity,
+            product_type=product_type,
+        )
 
 
 class Loader(LoaderPlugin):

--- a/client/ayon_tvpaint/api/plugin.py
+++ b/client/ayon_tvpaint/api/plugin.py
@@ -103,8 +103,6 @@ class TVPaintCreatorCommon:
         if project_entity is None:
             project_entity = self.create_context.get_current_project_entity()
 
-        if not product_type:
-            product_type = self.product_base_type
         # NOTE this is a workaround for backwards and forwards compatibility
         #   of 'get_dynamic_data' signature
         dyn_data_kwargs = dict(
@@ -130,6 +128,8 @@ class TVPaintCreatorCommon:
         get_product_name_kwargs = {}
 
         if getattr(get_product_name, "use_entities", False):
+            if not product_type:
+                product_type = self.product_base_type
             get_product_name_kwargs.update({
                 "folder_entity": folder_entity,
                 "task_entity": task_entity,

--- a/client/ayon_tvpaint/plugins/create/create_render.py
+++ b/client/ayon_tvpaint/plugins/create/create_render.py
@@ -239,10 +239,10 @@ class CreateRenderlayer(TVPaintCreator):
 
         self.log.info(f"Product name is {product_name}")
         new_instance = CreatedInstance(
-            self.product_type,
-            product_name,
-            instance_data,
-            self
+            product_type=self.product_base_type,
+            product_name=product_name,
+            data=instance_data,
+            creator=self
         )
         self._store_new_instance(new_instance)
 
@@ -706,10 +706,10 @@ class CreateRenderPass(TVPaintCreator):
         )
 
         new_instance = CreatedInstance(
-            self.product_type,
-            product_name,
-            instance_data,
-            self
+            product_type=self.product_base_type,
+            product_name=product_name,
+            data=instance_data,
+            creator=self,
         )
         instances_data = self._remove_and_filter_instances(
             instances_to_remove
@@ -1455,7 +1455,10 @@ class TVPaintSceneRenderCreator(TVPaintAutoCreator):
             data["active"] = False
 
         new_instance = CreatedInstance(
-            self.product_type, product_name, data, self
+            product_type=self.product_base_type,
+            product_name=product_name,
+            data=data,
+            creator=self,
         )
         instances_data = self.host.list_instances()
         instances_data.append(new_instance.data_to_store())

--- a/client/ayon_tvpaint/plugins/create/create_render.py
+++ b/client/ayon_tvpaint/plugins/create/create_render.py
@@ -519,26 +519,11 @@ class CreateRenderPass(TVPaintCreator):
                 render_layer_info.get("template_data"),
             )
 
-    def get_dynamic_data(
-        self,
-        project_name,
-        folder_entity,
-        task_entity,
-        variant,
-        host_name,
-        instance
-    ):
-        dynamic_data = super().get_dynamic_data(
-            project_name,
-            folder_entity,
-            task_entity,
-            variant,
-            host_name,
-            instance
-        )
-        dynamic_data["renderpass"] = "{renderpass}"
-        dynamic_data["renderlayer"] = "{renderlayer}"
-        return dynamic_data
+    def get_dynamic_data(self, *args, **kwargs) -> dict[str, Any]:
+        return {
+            "renderpass": "{renderpass}",
+            "renderlayer": "{renderlayer}",
+        }
 
     def update_instance_labels(
         self,

--- a/client/ayon_tvpaint/plugins/create/create_render.py
+++ b/client/ayon_tvpaint/plugins/create/create_render.py
@@ -154,13 +154,15 @@ class CreateRenderlayer(TVPaintCreator):
 
     def get_dynamic_data(
         self,
-        project_name,
-        folder_entity,
-        task_entity,
-        variant,
-        host_name,
-        instance
-    ):
+        project_name: str,
+        folder_entity: Optional[dict[str, Any]],
+        task_entity: Optional[dict[str, Any]],
+        variant: str,
+        host_name: Optional[str] = None,
+        instance: Optional[CreatedInstance] = None,
+        project_entity: Optional[dict[str, Any]] = None,
+        product_type: Optional[str] = None,
+    ) -> dict[str, Any]:
         return {
             "renderpass": self.default_pass_name,
             "renderlayer": variant,
@@ -1408,13 +1410,15 @@ class TVPaintSceneRenderCreator(TVPaintAutoCreator):
 
     def get_dynamic_data(
         self,
-        project_name,
-        folder_entity,
-        task_entity,
-        variant,
-        host_name,
-        instance
-    ):
+        project_name: str,
+        folder_entity: Optional[dict[str, Any]],
+        task_entity: Optional[dict[str, Any]],
+        variant: str,
+        host_name: Optional[str] = None,
+        instance: Optional[CreatedInstance] = None,
+        project_entity: Optional[dict[str, Any]] = None,
+        product_type: Optional[str] = None,
+    ) -> dict[str, Any]:
         return {
             "renderpass": "{renderpass}",
             "renderlayer": variant,

--- a/client/ayon_tvpaint/plugins/create/create_render.py
+++ b/client/ayon_tvpaint/plugins/create/create_render.py
@@ -239,10 +239,10 @@ class CreateRenderlayer(TVPaintCreator):
 
         self.log.info(f"Product name is {product_name}")
         new_instance = CreatedInstance(
-            product_type=self.product_base_type,
-            product_name=product_name,
-            data=instance_data,
-            creator=self
+            self.product_base_type,
+            product_name,
+            instance_data,
+            self
         )
         self._store_new_instance(new_instance)
 
@@ -706,10 +706,10 @@ class CreateRenderPass(TVPaintCreator):
         )
 
         new_instance = CreatedInstance(
-            product_type=self.product_base_type,
-            product_name=product_name,
-            data=instance_data,
-            creator=self,
+            self.product_base_type,
+            product_name,
+            instance_data,
+            self,
         )
         instances_data = self._remove_and_filter_instances(
             instances_to_remove
@@ -1455,10 +1455,10 @@ class TVPaintSceneRenderCreator(TVPaintAutoCreator):
             data["active"] = False
 
         new_instance = CreatedInstance(
-            product_type=self.product_base_type,
-            product_name=product_name,
-            data=data,
-            creator=self,
+            self.product_base_type,
+            product_name,
+            data,
+            self,
         )
         instances_data = self.host.list_instances()
         instances_data.append(new_instance.data_to_store())

--- a/client/ayon_tvpaint/plugins/create/create_review.py
+++ b/client/ayon_tvpaint/plugins/create/create_review.py
@@ -52,7 +52,7 @@ class TVPaintReviewCreator(TVPaintAutoCreator):
             data["active"] = False
 
         new_instance = CreatedInstance(
-            self.product_type,
+            self.product_base_type,
             product_name,
             data,
             self,

--- a/client/ayon_tvpaint/plugins/create/create_review.py
+++ b/client/ayon_tvpaint/plugins/create/create_review.py
@@ -52,7 +52,10 @@ class TVPaintReviewCreator(TVPaintAutoCreator):
             data["active"] = False
 
         new_instance = CreatedInstance(
-            self.product_type, product_name, data, self
+            self.product_type,
+            product_name,
+            data,
+            self,
         )
         instances_data = self.host.list_instances()
         instances_data.append(new_instance.data_to_store())

--- a/client/ayon_tvpaint/plugins/create/create_workfile.py
+++ b/client/ayon_tvpaint/plugins/create/create_workfile.py
@@ -45,7 +45,10 @@ class TVPaintWorkfileCreator(TVPaintAutoCreator):
         }
 
         new_instance = CreatedInstance(
-            self.product_type, product_name, data, self
+            self.product_type,
+            product_name,
+            data,
+            self,
         )
         instances_data = self.host.list_instances()
         instances_data.append(new_instance.data_to_store())

--- a/client/ayon_tvpaint/plugins/create/create_workfile.py
+++ b/client/ayon_tvpaint/plugins/create/create_workfile.py
@@ -45,7 +45,7 @@ class TVPaintWorkfileCreator(TVPaintAutoCreator):
         }
 
         new_instance = CreatedInstance(
-            self.product_type,
+            self.product_base_type,
             product_name,
             data,
             self,


### PR DESCRIPTION
## Changelog Description
Change how arguments to product name related functions and methods are passed and handled.

## Additional review information
Method `get_product_name` now can expect and work with product type.

## Testing notes:
TVPaint can work with last ayon-core release and with [this PR](https://github.com/ynput/ayon-core/pull/1656).
1. Use last ayon-core release and ayon-tvpaint from this PR.
2. Open a workfile.
3. Create an instance.
4. Change ayon-core to use https://github.com/ynput/ayon-core/pull/1656 .
5. Open the same workfile.
6. The instance should be available.
7. You can create new instance.