### PR TITLE
Chore: Support product base type in get_versioning_start signature vol 2 

### DIFF
--- a/client/ayon_tvpaint/plugins/load/load_workfile.py
+++ b/client/ayon_tvpaint/plugins/load/load_workfile.py
@@ -115,13 +115,14 @@ class LoadWorkfile(plugin.Loader):
                 host_name="tvpaint",
                 task_name=task_name,
                 task_type=data["task"]["type"],
-                product_type="workfile",
                 product_base_type="workfile",
             )
+            # Backwards compatibility
+            # TODO remove when ayon-core requirements is bumped above 1.8.0
             if not is_func_signature_supported(
                 get_versioning_start, **kwargs
             ):
-                kwargs.pop("product_base_type")
+                kwargs["procuct_type"] = kwargs.pop("product_base_type")
             version = get_versioning_start(**kwargs)
         else:
             version += 1

--- a/client/ayon_tvpaint/plugins/load/load_workfile.py
+++ b/client/ayon_tvpaint/plugins/load/load_workfile.py
@@ -122,7 +122,7 @@ class LoadWorkfile(plugin.Loader):
             if not is_func_signature_supported(
                 get_versioning_start, **kwargs
             ):
-                kwargs["procuct_type"] = kwargs.pop("product_base_type")
+                kwargs["product_type"] = kwargs.pop("product_base_type")
             version = get_versioning_start(**kwargs)
         else:
             version += 1


### PR DESCRIPTION
## Changelog Description
Pass only product base type or product type, not both.

## Additional review information
Extended variant of https://github.com/ynput/ayon-tvpaint/pull/67 . Do not pass both product base type and product type, instead pass only one of them.

## Testing notes:
1. Work with current ayon-core and new ayon-core with https://github.com/ynput/ayon-core/pull/1667 .