### PR TITLE
🏛️Product base types: Product types and base types

### DIFF
--- a/client/ayon_tvpaint/api/plugin.py
+++ b/client/ayon_tvpaint/api/plugin.py
@@ -1,7 +1,6 @@
 import re
 from typing import Optional, Any
 
-from ayon_core.lib import is_func_signature_supported
 from ayon_core.pipeline import LoaderPlugin
 from ayon_core.pipeline.create import (
     CreatedInstance,
@@ -19,8 +18,8 @@ SHARED_DATA_KEY = "ayon.tvpaint.instances"
 
 class TVPaintCreatorCommon:
     @property
-    def product_template_product_type(self):
-        return self.product_type
+    def product_template_product_base_type(self):
+        return self.product_base_type
 
     def _cache_and_get_instances(self):
         return cache_and_get_instances(
@@ -103,9 +102,10 @@ class TVPaintCreatorCommon:
         if project_entity is None:
             project_entity = self.create_context.get_current_project_entity()
 
-        # NOTE this is a workaround for backwards and forwards compatibility
-        #   of 'get_dynamic_data' signature
-        dyn_data_kwargs = dict(
+        if not product_type:
+            product_type = self.product_base_type
+
+        dynamic_data = self.get_dynamic_data(
             project_name=project_name,
             folder_entity=folder_entity,
             task_entity=task_entity,
@@ -115,48 +115,20 @@ class TVPaintCreatorCommon:
             project_entity=project_entity,
             product_type=product_type,
         )
-        for kwarg in ("product_type", "project_entity"):
-            if not is_func_signature_supported(
-                self.get_dynamic_data, **dyn_data_kwargs
-            ):
-                dyn_data_kwargs.pop(kwarg)
-        dynamic_data = self.get_dynamic_data(**dyn_data_kwargs)
-
-        task_name = task_type = None
-        if task_entity:
-            task_name = task_entity["name"]
-            task_type = task_entity["taskType"]
-
-        get_product_name_kwargs = {}
-
-        if getattr(get_product_name, "use_entities", False):
-            if not product_type:
-                product_type = self.product_base_type
-            get_product_name_kwargs.update({
-                "folder_entity": folder_entity,
-                "task_entity": task_entity,
-                "product_type": product_type,
-                "product_base_type": self.product_base_type,
-                "product_base_type_filter": (
-                    self.product_template_product_type
-                ),
-            })
-        else:
-            get_product_name_kwargs.update({
-                "product_type": self.product_base_type,
-                "task_name": task_name,
-                "task_type": task_type,
-                "product_type_filter": self.product_template_product_type,
-            })
-
         return get_product_name(
             project_name=project_name,
+            project_entity=project_entity,
+            folder_entity=folder_entity,
+            task_entity=task_entity,
+            product_base_type=self.product_base_type,
+            product_type=product_type,
             host_name=host_name,
             variant=variant,
             dynamic_data=dynamic_data,
             project_settings=self.project_settings,
-            project_entity=project_entity,
-            **get_product_name_kwargs
+            product_base_type_filter=(
+                self.product_template_product_base_type
+            ),
         )
 
 

--- a/client/ayon_tvpaint/api/plugin.py
+++ b/client/ayon_tvpaint/api/plugin.py
@@ -140,6 +140,7 @@ class TVPaintCreator(Creator, TVPaintCreatorCommon):
     def apply_settings(self, project_settings):
         create_settings = project_settings["tvpaint"]["create"]
         self._use_current_context = create_settings["use_current_context"]
+        super().apply_settings(project_settings)
 
     def collect_instances(self):
         self._collect_create_instances()

--- a/client/ayon_tvpaint/api/plugin.py
+++ b/client/ayon_tvpaint/api/plugin.py
@@ -134,6 +134,7 @@ class TVPaintCreatorCommon:
 
 class TVPaintCreator(Creator, TVPaintCreatorCommon):
     settings_category = "tvpaint"
+    skip_discovery = True
     _use_current_context = False
 
     def apply_settings(self, project_settings):
@@ -201,6 +202,7 @@ class TVPaintCreator(Creator, TVPaintCreatorCommon):
 
 class TVPaintAutoCreator(AutoCreator, TVPaintCreatorCommon):
     settings_category = "tvpaint"
+    skip_discovery = True
 
     def collect_instances(self):
         self._collect_create_instances()
@@ -234,6 +236,7 @@ class TVPaintAutoCreator(AutoCreator, TVPaintCreatorCommon):
 class Loader(LoaderPlugin):
     hosts = ["tvpaint"]
     settings_category = "tvpaint"
+    skip_discovery = True
 
     @staticmethod
     def get_members_from_container(container):

--- a/client/ayon_tvpaint/plugins/create/convert_legacy.py
+++ b/client/ayon_tvpaint/plugins/create/convert_legacy.py
@@ -102,6 +102,7 @@ class TVPaintLegacyConverted(ProductConvertorPlugin):
                 "group_id": group_id
             }
             render_layer["productType"] = "render"
+            render_layer["productBaseType"] = "render"
             group = groups_by_id[group_id]
             # Use group name for variant
             group["variant"] = group["name"]
@@ -129,6 +130,7 @@ class TVPaintLegacyConverted(ProductConvertorPlugin):
             render_pass["creator_identifier"] = "render.pass"
             render_pass["instance_id"] = render_pass.pop("uuid")
             render_pass["productType"] = "render"
+            render_pass["productBaseType"] = "render"
 
             render_pass["creator_attributes"] = {
                 "render_layer_instance_id": render_layer["instance_id"]

--- a/client/ayon_tvpaint/plugins/create/create_render.py
+++ b/client/ayon_tvpaint/plugins/create/create_render.py
@@ -119,9 +119,9 @@ class CreateRenderlayer(TVPaintCreator):
     """
 
     label = "Render Layer"
-    product_type = "render"
     product_base_type = "render"
-    product_template_product_type = "renderLayer"
+    product_type = product_base_type
+    product_template_product_base_type = "renderLayer"
     identifier = "render.layer"
     icon = "fa5.images"
 
@@ -406,9 +406,9 @@ class CreateRenderlayer(TVPaintCreator):
 
 
 class CreateRenderPass(TVPaintCreator):
-    product_type = "render"
     product_base_type = "render"
-    product_template_product_type = "renderPass"
+    product_type = product_base_type
+    product_template_product_base_type = "renderPass"
     identifier = "render.pass"
     label = "Render Pass"
     icon = "fa5.image"
@@ -960,8 +960,8 @@ class TVPaintAutoDetectRenderCreator(TVPaintCreator):
     Never will have any instances, all instances belong to different creators.
     """
 
-    product_type = "render"
     product_base_type = "render"
+    product_type = product_base_type
     label = "Render Layer/Passes"
     identifier = "render.auto.detect.creator"
     order = CreateRenderPass.order + 10
@@ -1359,9 +1359,9 @@ class TVPaintAutoDetectRenderCreator(TVPaintCreator):
 
 
 class TVPaintSceneRenderCreator(TVPaintAutoCreator):
-    product_type = "render"
     product_base_type = "render"
-    product_template_product_type = "renderScene"
+    product_type = product_base_type
+    product_template_product_base_type = "renderScene"
     identifier = "render.scene"
     label = "Scene Render"
     icon = "fa.file-image-o"

--- a/client/ayon_tvpaint/plugins/create/create_render.py
+++ b/client/ayon_tvpaint/plugins/create/create_render.py
@@ -134,6 +134,7 @@ class CreateRenderlayer(TVPaintCreator):
     order = 90
     description = "Mark TVPaint color group as one Render Layer."
     detailed_description = RENDER_LAYER_DETAILED_DESCRIPTIONS
+    settings_name = "create_render_layer"
 
     # Settings
     # - Default render pass name for beauty
@@ -143,13 +144,6 @@ class CreateRenderlayer(TVPaintCreator):
 
     def apply_settings(self, project_settings):
         super().apply_settings(project_settings)
-        plugin_settings = (
-            project_settings["tvpaint"]["create"]["create_render_layer"]
-        )
-        self.default_variant = plugin_settings["default_variant"]
-        self.default_variants = plugin_settings["default_variants"]
-        self.default_pass_name = plugin_settings["default_pass_name"]
-        self.mark_for_review = plugin_settings["mark_for_review"]
         self.create_allow_context_change = not self._use_current_context
 
     def get_dynamic_data(

--- a/client/ayon_tvpaint/plugins/create/create_render.py
+++ b/client/ayon_tvpaint/plugins/create/create_render.py
@@ -174,6 +174,10 @@ class CreateRenderlayer(TVPaintCreator):
 
         group_name = instance_data["variant"]
 
+        product_type = instance_data.get("productType")
+        if not product_type:
+            product_type = self.product_base_type
+
         if self._use_current_context:
             project_name = self.create_context.get_current_project_name()
             folder_entity = self.create_context.get_current_folder_entity()
@@ -186,6 +190,7 @@ class CreateRenderlayer(TVPaintCreator):
                 folder_entity=folder_entity,
                 task_entity=task_entity,
                 variant=group_name,
+                product_type=product_type,
             )
 
             instance_data["folderPath"] = folder_entity["path"]
@@ -233,10 +238,11 @@ class CreateRenderlayer(TVPaintCreator):
 
         self.log.info(f"Product name is {product_name}")
         new_instance = CreatedInstance(
-            self.product_base_type,
-            product_name,
-            instance_data,
-            self
+            product_base_type=self.product_base_type,
+            product_type=product_type,
+            product_name=product_name,
+            data=instance_data,
+            creator=self,
         )
         self._store_new_instance(new_instance)
 
@@ -570,6 +576,10 @@ class CreateRenderPass(TVPaintCreator):
                 f" by id \"{render_layer_instance_id}\""
             ))
 
+        product_type = instance_data.get("productType")
+        if not product_type:
+            product_type = self.product_base_type
+
         if self._use_current_context:
             project_name = self.create_context.get_current_project_name()
             folder_entity = self.create_context.get_current_folder_entity()
@@ -582,6 +592,7 @@ class CreateRenderPass(TVPaintCreator):
                 folder_entity=folder_entity,
                 task_entity=task_entity,
                 variant=instance_data["variant"],
+                product_type=product_type,
             )
 
             instance_data["folderPath"] = folder_entity["path"]
@@ -689,10 +700,11 @@ class CreateRenderPass(TVPaintCreator):
         )
 
         new_instance = CreatedInstance(
-            self.product_base_type,
-            product_name,
-            instance_data,
-            self,
+            product_base_type=self.product_base_type,
+            product_type=product_type,
+            product_name=product_name,
+            data=instance_data,
+            creator=self,
         )
         instances_data = self._remove_and_filter_instances(
             instances_to_remove
@@ -1048,6 +1060,7 @@ class TVPaintAutoDetectRenderCreator(TVPaintCreator):
         project_entity: dict[str, Any],
         folder_entity: dict[str, Any],
         task_entity: dict[str, Any],
+        product_type: Optional[str],
         group_id: int,
         groups: list[dict[str, Any]],
         mark_for_review: bool,
@@ -1069,6 +1082,7 @@ class TVPaintAutoDetectRenderCreator(TVPaintCreator):
         creator: CreateRenderlayer = (
             self.create_context.creators[CreateRenderlayer.identifier]
         )
+        product_type = product_type or creator.product_base_type
         product_name: str = creator.get_product_name(
             project_name=project_entity["name"],
             folder_entity=folder_entity,
@@ -1076,6 +1090,7 @@ class TVPaintAutoDetectRenderCreator(TVPaintCreator):
             variant=variant,
             host_name=self.create_context.host_name,
             project_entity=project_entity,
+            product_type=product_type,
         )
         if existing_instance is not None:
             existing_instance["folderPath"] = folder_entity["path"]
@@ -1086,7 +1101,8 @@ class TVPaintAutoDetectRenderCreator(TVPaintCreator):
         instance_data: dict[str, str] = {
             "folderPath": folder_entity["path"],
             "task": task_name,
-            "productType": creator.product_type,
+            "productBaseType": creator.product_base_type,
+            "productType": product_type,
             "variant": variant,
         }
         pre_create_data: dict[str, Any] = {
@@ -1101,6 +1117,7 @@ class TVPaintAutoDetectRenderCreator(TVPaintCreator):
         folder_entity: dict[str, Any],
         task_entity: dict[str, Any],
         render_layer_instance: CreatedInstance,
+        product_type: Optional[str],
         layers: list[dict[str, Any]],
         mark_for_review: bool,
         existing_render_passes: list[CreatedInstance]
@@ -1109,6 +1126,7 @@ class TVPaintAutoDetectRenderCreator(TVPaintCreator):
         creator: CreateRenderPass = (
             self.create_context.creators[CreateRenderPass.identifier]
         )
+        product_type = product_type or creator.product_base_type
         render_pass_by_layer_name = {}
         for render_pass in existing_render_passes:
             for layer_name in render_pass["layer_names"]:
@@ -1166,6 +1184,7 @@ class TVPaintAutoDetectRenderCreator(TVPaintCreator):
                 host_name=self.create_context.host_name,
                 instance=render_pass,
                 project_entity=project_entity,
+                product_type=product_type,
             )
 
             if render_pass is not None:
@@ -1177,7 +1196,8 @@ class TVPaintAutoDetectRenderCreator(TVPaintCreator):
             instance_data: dict[str, str] = {
                 "folderPath": folder_entity["path"],
                 "task": task_name,
-                "productType": creator.product_type,
+                "productBaseType": creator.product_base_type,
+                "productType": product_type,
                 "variant": variant
             }
 
@@ -1271,6 +1291,9 @@ class TVPaintAutoDetectRenderCreator(TVPaintCreator):
         )
         rename_groups = pre_create_data.get("rename_groups", False)
         only_visible_groups = pre_create_data.get("only_visible_groups", False)
+
+        layer_product_type = pre_create_data.get("layer_product_type")
+        pass_product_type = pre_create_data.get("pass_product_type")
         groups_order = self._filter_groups(
             layers_by_group_id,
             groups_order,
@@ -1289,6 +1312,7 @@ class TVPaintAutoDetectRenderCreator(TVPaintCreator):
                     project_entity,
                     folder_entity,
                     task_entity,
+                    layer_product_type,
                     group_id,
                     scene_groups,
                     mark_layers_for_review,
@@ -1311,6 +1335,7 @@ class TVPaintAutoDetectRenderCreator(TVPaintCreator):
                 folder_entity,
                 task_entity,
                 render_layer_instance,
+                pass_product_type,
                 layers,
                 mark_passes_for_review,
                 render_passes_by_render_layer_id[render_layer_instance.id]
@@ -1323,7 +1348,39 @@ class TVPaintAutoDetectRenderCreator(TVPaintCreator):
         render_pass_creator: CreateRenderPass = (
             self.create_context.creators[CreateRenderPass.identifier]
         )
+        layer_product_type_items = [
+            {
+                "value": item.product_type,
+                "label": item.label or item.product_type,
+            }
+            for item in render_layer_creator.product_type_items
+        ]
+
+        pass_product_type_items = [
+            {
+                "value": item.product_type,
+                "label": item.label or item.product_type,
+            }
+            for item in render_pass_creator.product_type_items
+        ]
+
         output = []
+        if layer_product_type_items:
+            output.append(EnumDef(
+                "layer_product_type",
+                label="Render layer product type",
+                items=layer_product_type_items,
+                default=layer_product_type_items[0]["value"],
+            ))
+
+        if pass_product_type_items:
+            output.append(EnumDef(
+                "pass_product_type",
+                label="Render pass product type",
+                items=pass_product_type_items,
+                default=pass_product_type_items[0]["value"],
+            ))
+
         if self.allow_group_rename:
             output.extend([
                 BoolDef(
@@ -1395,6 +1452,7 @@ class TVPaintSceneRenderCreator(TVPaintAutoCreator):
         project_name = create_context.get_current_project_name()
         folder_entity = create_context.get_current_folder_entity()
         task_entity = create_context.get_current_task_entity()
+        product_type = self.product_type or self.product_base_type
 
         product_name = self.get_product_name(
             project_name=project_name,
@@ -1402,6 +1460,7 @@ class TVPaintSceneRenderCreator(TVPaintAutoCreator):
             task_entity=task_entity,
             variant=self.default_variant,
             host_name=host_name,
+            product_type=product_type,
         )
         data = {
             "folderPath": folder_entity["path"],
@@ -1420,10 +1479,11 @@ class TVPaintSceneRenderCreator(TVPaintAutoCreator):
             data["active"] = False
 
         new_instance = CreatedInstance(
-            self.product_base_type,
-            product_name,
-            data,
-            self,
+            product_base_type=self.product_base_type,
+            product_type=product_type,
+            product_name=product_name,
+            data=data,
+            creator=self,
         )
         instances_data = self.host.list_instances()
         instances_data.append(new_instance.data_to_store())
@@ -1446,11 +1506,13 @@ class TVPaintSceneRenderCreator(TVPaintAutoCreator):
         project_name = create_context.get_current_project_name()
         folder_path = create_context.get_current_folder_path()
         task_name = create_context.get_current_task_name()
+        product_type = self.product_type or self.product_base_type
 
         existing_name = existing_instance.get("folderPath")
         if (
             existing_name != folder_path
             or existing_instance["task"] != task_name
+            or existing_instance.product_type != product_type
         ):
             folder_entity = self.create_context.get_folder_entity(folder_path)
             task_entity = self.create_context.get_task_entity(
@@ -1463,6 +1525,7 @@ class TVPaintSceneRenderCreator(TVPaintAutoCreator):
                 variant=existing_instance["variant"],
                 host_name=host_name,
                 instance=existing_instance,
+                product_type=product_type,
             )
             existing_instance["folderPath"] = folder_path
             existing_instance["task"] = task_name

--- a/client/ayon_tvpaint/plugins/create/create_render.py
+++ b/client/ayon_tvpaint/plugins/create/create_render.py
@@ -420,6 +420,7 @@ class CreateRenderPass(TVPaintCreator):
     icon = "fa5.image"
     description = "Mark selected TVPaint layers as pass of Render Layer."
     detailed_description = RENDER_PASS_DETAILED_DESCRIPTIONS
+    settings_name = "create_render_pass"
 
     order = CreateRenderlayer.order + 10
 
@@ -445,18 +446,6 @@ class CreateRenderPass(TVPaintCreator):
 
     def apply_settings(self, project_settings):
         super().apply_settings(project_settings)
-        plugin_settings = (
-            project_settings["tvpaint"]["create"]["create_render_pass"]
-        )
-        self.layer_name_template = plugin_settings["layer_name_template"]
-        self.group_idx_offset = plugin_settings["group_idx_offset"]
-        self.group_idx_padding = plugin_settings["group_idx_padding"]
-        self.layer_idx_offset = plugin_settings["layer_idx_offset"]
-        self.layer_idx_padding = plugin_settings["layer_idx_padding"]
-        self.default_variant = plugin_settings["default_variant"]
-        self.default_variants = plugin_settings["default_variants"]
-        self.mark_for_review = plugin_settings["mark_for_review"]
-        self.render_pass_template = plugin_settings["render_pass_template"]
         self.create_allow_context_change = not self._use_current_context
 
     def collect_instances(self):
@@ -982,6 +971,7 @@ class TVPaintAutoDetectRenderCreator(TVPaintCreator):
     label = "Render Layer/Passes"
     identifier = "render.auto.detect.creator"
     order = CreateRenderPass.order + 10
+    settings_name = "auto_detect_render"
     description = (
         "Create Render Layers and Render Passes based on scene setup"
     )
@@ -997,17 +987,6 @@ class TVPaintAutoDetectRenderCreator(TVPaintCreator):
 
     def apply_settings(self, project_settings):
         super().apply_settings(project_settings)
-        plugin_settings = (
-            project_settings
-            ["tvpaint"]
-            ["create"]
-            ["auto_detect_render"]
-        )
-        self.enabled = plugin_settings.get("enabled", False)
-        self.allow_group_rename = plugin_settings["allow_group_rename"]
-        self.group_name_template = plugin_settings["group_name_template"]
-        self.group_idx_offset = plugin_settings["group_idx_offset"]
-        self.group_idx_padding = plugin_settings["group_idx_padding"]
         self.create_allow_context_change = not self._use_current_context
 
         render_pass_settings = (
@@ -1393,20 +1372,12 @@ class TVPaintSceneRenderCreator(TVPaintAutoCreator):
     label = "Scene Render"
     icon = "fa.file-image-o"
 
+    settings_name = "create_render_scene"
+
     # Settings
     default_pass_name = "beauty"
     mark_for_review = True
     active_on_create = False
-
-    def apply_settings(self, project_settings):
-        plugin_settings = (
-            project_settings["tvpaint"]["create"]["create_render_scene"]
-        )
-        self.default_variant = plugin_settings["default_variant"]
-        self.default_variants = plugin_settings["default_variants"]
-        self.mark_for_review = plugin_settings["mark_for_review"]
-        self.active_on_create = plugin_settings["active_on_create"]
-        self.default_pass_name = plugin_settings["default_pass_name"]
 
     def get_dynamic_data(
         self,

--- a/client/ayon_tvpaint/plugins/create/create_review.py
+++ b/client/ayon_tvpaint/plugins/create/create_review.py
@@ -3,8 +3,8 @@ from ayon_tvpaint.api.plugin import TVPaintAutoCreator
 
 
 class TVPaintReviewCreator(TVPaintAutoCreator):
-    product_type = "review"
     product_base_type = "review"
+    product_type = product_base_type
     identifier = "scene.review"
     label = "Review"
     icon = "ei.video"

--- a/client/ayon_tvpaint/plugins/create/create_review.py
+++ b/client/ayon_tvpaint/plugins/create/create_review.py
@@ -9,16 +9,10 @@ class TVPaintReviewCreator(TVPaintAutoCreator):
     label = "Review"
     icon = "ei.video"
 
+    settings_name = "create_review"
+
     # Settings
     active_on_create = True
-
-    def apply_settings(self, project_settings):
-        plugin_settings = (
-            project_settings["tvpaint"]["create"]["create_review"]
-        )
-        self.default_variant = plugin_settings["default_variant"]
-        self.default_variants = plugin_settings["default_variants"]
-        self.active_on_create = plugin_settings["active_on_create"]
 
     def create(self):
         existing_instance = None

--- a/client/ayon_tvpaint/plugins/create/create_workfile.py
+++ b/client/ayon_tvpaint/plugins/create/create_workfile.py
@@ -8,13 +8,7 @@ class TVPaintWorkfileCreator(TVPaintAutoCreator):
     identifier = "workfile"
     label = "Workfile"
     icon = "fa.file-o"
-
-    def apply_settings(self, project_settings):
-        plugin_settings = (
-            project_settings["tvpaint"]["create"]["create_workfile"]
-        )
-        self.default_variant = plugin_settings["default_variant"]
-        self.default_variants = plugin_settings["default_variants"]
+    settings_name = "create_workfile"
 
     def create(self):
         existing_instance = None

--- a/client/ayon_tvpaint/plugins/create/create_workfile.py
+++ b/client/ayon_tvpaint/plugins/create/create_workfile.py
@@ -3,8 +3,8 @@ from ayon_tvpaint.api.plugin import TVPaintAutoCreator
 
 
 class TVPaintWorkfileCreator(TVPaintAutoCreator):
-    product_type = "workfile"
     product_base_type = "workfile"
+    product_type = product_base_type
     identifier = "workfile"
     label = "Workfile"
     icon = "fa.file-o"

--- a/client/ayon_tvpaint/plugins/load/load_image.py
+++ b/client/ayon_tvpaint/plugins/load/load_image.py
@@ -6,7 +6,8 @@ from ayon_tvpaint.api.lib import execute_george_through_file
 class ImportImage(plugin.Loader):
     """Load image or image sequence to TVPaint as new layer."""
 
-    product_types = {"render", "image", "background", "plate", "review"}
+    product_base_types = {"render", "image", "background", "plate", "review"}
+    product_types = product_base_types
     representations = {"*"}
     settings_category = "tvpaint"
 

--- a/client/ayon_tvpaint/plugins/load/load_reference_image.py
+++ b/client/ayon_tvpaint/plugins/load/load_reference_image.py
@@ -17,7 +17,8 @@ from ayon_tvpaint.api.pipeline import (
 class LoadImage(plugin.Loader):
     """Load image or image sequence to TVPaint as new layer."""
 
-    product_types = {"render", "image", "background", "plate", "review"}
+    product_base_types = {"render", "image", "background", "plate", "review"}
+    product_types = product_base_types
     representations = {"*"}
     settings_category = "tvpaint"
 

--- a/client/ayon_tvpaint/plugins/load/load_sound.py
+++ b/client/ayon_tvpaint/plugins/load/load_sound.py
@@ -22,7 +22,8 @@ class ImportSound(plugin.Loader):
     file contain any audio.
     """
 
-    product_types = {"audio", "review", "plate"}
+    product_base_types = {"audio", "review", "plate"}
+    product_types = product_base_types
     representations = {"*"}
 
     label = "Import Sound"

--- a/client/ayon_tvpaint/plugins/load/load_workfile.py
+++ b/client/ayon_tvpaint/plugins/load/load_workfile.py
@@ -26,7 +26,8 @@ from ayon_core.pipeline.version_start import get_versioning_start
 class LoadWorkfile(plugin.Loader):
     """Load workfile."""
 
-    product_types = {"workfile"}
+    product_base_types = {"workfile"}
+    product_types = product_base_types
     representations = {"tvpp"}
 
     label = "Load Workfile"

--- a/client/ayon_tvpaint/plugins/load/load_workfile.py
+++ b/client/ayon_tvpaint/plugins/load/load_workfile.py
@@ -2,7 +2,6 @@ import os
 
 import ayon_api
 
-from ayon_core.lib import is_func_signature_supported
 from ayon_core.pipeline import (
     registered_host,
     get_current_context,
@@ -111,20 +110,13 @@ class LoadWorkfile(plugin.Loader):
         )[1]
 
         if version is None:
-            kwargs = dict(
+            version = get_versioning_start(
                 project_name=project_name,
                 host_name="tvpaint",
                 task_name=task_name,
                 task_type=data["task"]["type"],
                 product_base_type="workfile",
             )
-            # Backwards compatibility
-            # TODO remove when ayon-core requirements is bumped above 1.8.0
-            if not is_func_signature_supported(
-                get_versioning_start, **kwargs
-            ):
-                kwargs["product_type"] = kwargs.pop("product_base_type")
-            version = get_versioning_start(**kwargs)
         else:
             version += 1
 

--- a/client/ayon_tvpaint/plugins/publish/extract_sequence.py
+++ b/client/ayon_tvpaint/plugins/publish/extract_sequence.py
@@ -120,7 +120,7 @@ class ExtractSequence(pyblish.api.InstancePlugin):
             "Files will be rendered to folder: {}".format(output_dir)
         )
 
-        if instance.data["productType"] == "review":
+        if instance.data["productBaseType"] == "review":
             result = self.render_review(
                 output_dir, mark_in, mark_out, scene_bg_color
             )

--- a/server/settings/create_plugins.py
+++ b/server/settings/create_plugins.py
@@ -1,6 +1,19 @@
 from ayon_server.settings import BaseSettingsModel, SettingsField
 
 
+class ProductTypeItemModel(BaseSettingsModel):
+    _layout = "compact"
+    product_type: str = SettingsField(
+        title="Product type",
+        description="Product type name"
+    )
+    label: str = SettingsField(
+        "",
+        title="Label",
+        description="Label to show in UI for the product type"
+    )
+
+
 class CreateWorkfileModel(BaseSettingsModel):
     enabled: bool = SettingsField(True)
     default_variant: str = SettingsField(title="Default variant")
@@ -24,6 +37,15 @@ class CreateRenderSceneModel(BaseSettingsModel):
     default_variant: str = SettingsField(title="Default variant")
     default_variants: list[str] = SettingsField(
         default_factory=list, title="Default variants")
+    product_type: str = SettingsField(
+        "",
+        title="Product type",
+        placeholder="Custom product type",
+        description=(
+            "Customize product type for UI purposes. Also may affect"
+            " final product name."
+        ),
+    )
 
 
 class CreateRenderLayerModel(BaseSettingsModel):
@@ -32,6 +54,13 @@ class CreateRenderLayerModel(BaseSettingsModel):
     default_variant: str = SettingsField(title="Default variant")
     default_variants: list[str] = SettingsField(
         default_factory=list, title="Default variants")
+    product_type_items: list[ProductTypeItemModel] = SettingsField(
+        default_factory=list,
+        title="Product type items",
+        description=(
+            "Optional list of product types this plugin can create."
+        ),
+    )
 
 
 class LayerNameTemplateModel(BaseSettingsModel):
@@ -77,6 +106,13 @@ class CreateRenderPassModel(BaseSettingsModel):
     )
     layer_idx_padding: int = SettingsField(
         3, title="Layer index Padding", ge=0
+    )
+    product_type_items: list[ProductTypeItemModel] = SettingsField(
+        default_factory=list,
+        title="Product type items",
+        description=(
+            "Optional list of product types this plugin can create."
+        ),
     )
 
 

--- a/server/settings/create_plugins.py
+++ b/server/settings/create_plugins.py
@@ -132,7 +132,7 @@ class AutoDetectCreateRenderModel(BaseSettingsModel):
     Would create group names "G010", "G020", ...
     """
 
-    enabled: bool = SettingsField(True)
+    enabled: bool = SettingsField(False)
     allow_group_rename: bool = SettingsField(title="Allow group rename")
     group_name_template: str = SettingsField(title="Group name template")
     group_idx_offset: int = SettingsField(


### PR DESCRIPTION
## Changelog Description
Use product base types and add support for product types used as aliases.

## Additional review information
Workfiles created with this PR cannot be used with older version of TVPaint addon (if product types are used)!!!

Codebase of TVPaint is fully using product base type as "pipeline" type and product type as an alias. Load plugins define `product_base_types` for filtering, create plugins do define `product_base_type` and the whole logic is expecting that product base type is being used in the system.

All create render plugins have option to define product type items or product type for render scene.

## Testing notes:
### Basics
1. Use ayon-core >= 1.8.0 or current develop if is not released yet.
2. Existing workfiles should load up and should be possible to publish.
3. Creating new instances should work as expected.

### Product types
1. Define product types for a create plugin.
2. Create an instance with the product type.
3. Product name should use the product type in name (if template defines that).
4. Publish the instance.
5. Loader tool should show the product type and product base type in UI.

Automated create plugin allows you to select product type for newly created instances, but only if the related create plugin has defined them.