### PR TITLE
Loaders: Filters by extension instead of representation name

### DIFF
--- a/client/ayon_tvpaint/plugins/load/load_workfile.py
+++ b/client/ayon_tvpaint/plugins/load/load_workfile.py
@@ -27,7 +27,8 @@ class LoadWorkfile(plugin.Loader):
 
     product_base_types = {"workfile"}
     product_types = product_base_types
-    representations = {"tvpp"}
+    representations = {"*"}
+    extensions = {"tvpp"}
 
     label = "Load Workfile"
 


### PR DESCRIPTION
## Changelog Description

Loaders: Filters by extension instead of representation name

## Additional review information

Make loaders filter by extension instead of representation name so they are less restrictive on what can be loaded.

## Testing notes:

1. Validate code changes
2. Loaders should still be able to load the right representations, etc.