### PR TITLE
Current File: Collect current file earlier

### DIFF
--- a/client/ayon_tvpaint/plugins/publish/collect_current_file.py
+++ b/client/ayon_tvpaint/plugins/publish/collect_current_file.py
@@ -1,0 +1,37 @@
+import pyblish.api
+
+from ayon_tvpaint.api.lib import execute_george
+
+
+class CollectCurrentFile(pyblish.api.ContextPlugin):
+    label = "Collect Current File"
+    order = pyblish.api.CollectorOrder - 0.5
+    hosts = ["tvpaint"]
+
+    def process(self, context):
+        current_project_id = execute_george("tv_projectcurrentid")
+        execute_george(f"tv_projectselect {current_project_id}")
+
+        self.log.debug("Collecting scene data from workfile")
+        workfile_info_parts = execute_george("tv_projectinfo").split(" ")
+
+        # Project frame start - not used
+        workfile_info_parts.pop(-1)
+        field_order = workfile_info_parts.pop(-1)
+        frame_rate = float(workfile_info_parts.pop(-1))
+        pixel_apsect = float(workfile_info_parts.pop(-1))
+        height = int(workfile_info_parts.pop(-1))
+        width = int(workfile_info_parts.pop(-1))
+        workfile_path = " ".join(workfile_info_parts).replace("\"", "")
+
+        scene_data = {
+            "currentFile": workfile_path,
+            "sceneWidth": width,
+            "sceneHeight": height,
+            "scenePixelAspect": pixel_apsect,
+            "sceneFps": frame_rate,
+            "sceneFieldOrder": field_order,
+            "sceneBgColor": self._get_bg_color(),
+        }
+        self.log.debug(f"Scene data: {scene_data}")
+        context.data.update(scene_data)

--- a/client/ayon_tvpaint/plugins/publish/collect_current_file.py
+++ b/client/ayon_tvpaint/plugins/publish/collect_current_file.py
@@ -31,7 +31,6 @@ class CollectCurrentFile(pyblish.api.ContextPlugin):
             "scenePixelAspect": pixel_apsect,
             "sceneFps": frame_rate,
             "sceneFieldOrder": field_order,
-            "sceneBgColor": self._get_bg_color(),
         }
         self.log.debug(f"Scene data: {scene_data}")
         context.data.update(scene_data)

--- a/client/ayon_tvpaint/plugins/publish/collect_workfile_data.py
+++ b/client/ayon_tvpaint/plugins/publish/collect_workfile_data.py
@@ -148,9 +148,6 @@ class CollectWorkfileData(pyblish.api.ContextPlugin):
             "Group data:\"{}".format(json.dumps(group_data, indent=4))
         )
 
-        self.log.info("Collecting scene data from workfile")
-        workfile_info_parts = execute_george("tv_projectinfo").split(" ")
-
         # Marks return as "{frame - 1} {state} ", example "0 set".
         result = execute_george("tv_markin")
         mark_in_frame, mark_in_state, _ = result.split(" ")

--- a/client/ayon_tvpaint/plugins/publish/collect_workfile_data.py
+++ b/client/ayon_tvpaint/plugins/publish/collect_workfile_data.py
@@ -151,15 +151,6 @@ class CollectWorkfileData(pyblish.api.ContextPlugin):
         self.log.info("Collecting scene data from workfile")
         workfile_info_parts = execute_george("tv_projectinfo").split(" ")
 
-        # Project frame start - not used
-        workfile_info_parts.pop(-1)
-        field_order = workfile_info_parts.pop(-1)
-        frame_rate = float(workfile_info_parts.pop(-1))
-        pixel_apsect = float(workfile_info_parts.pop(-1))
-        height = int(workfile_info_parts.pop(-1))
-        width = int(workfile_info_parts.pop(-1))
-        workfile_path = " ".join(workfile_info_parts).replace("\"", "")
-
         # Marks return as "{frame - 1} {state} ", example "0 set".
         result = execute_george("tv_markin")
         mark_in_frame, mark_in_state, _ = result.split(" ")
@@ -196,12 +187,6 @@ class CollectWorkfileData(pyblish.api.ContextPlugin):
             clip_index += 1
 
         scene_data = {
-            "currentFile": workfile_path,
-            "sceneWidth": width,
-            "sceneHeight": height,
-            "scenePixelAspect": pixel_apsect,
-            "sceneFps": frame_rate,
-            "sceneFieldOrder": field_order,
             "sceneMarkIn": int(mark_in_frame),
             "sceneMarkInState": mark_in_state == "set",
             "sceneMarkOut": int(mark_out_frame),


### PR DESCRIPTION
## Changelog Description
Collect current file as soon as possible during publishing.

## Additional review information
Workfile data collection was split into 2 plugins, as the original plugin has to run within the order it is defined in.

