### PR TITLE
Copy files: Fix hardlinking of files

### DIFF
--- a/client/ayon_tvpaint/lib.py
+++ b/client/ayon_tvpaint/lib.py
@@ -541,10 +541,16 @@ def copy_render_file(src_path, dst_path):
 
     try:
         os.link(src_path, dst_path)
-    except OSError:
+    except OSError as exc:
+        if exc.errno != 22:
+            raise
+        # Exceeded hardlink limit, create new copy of source file and re-start
+        #   the link limit.
+        # NOTE limit on NTFS is 1023 hardlinks
         shutil.copy(src_path, dst_path)
         os.remove(src_path)
-        shutil.copy(dst_path, src_path)
+        os.rename(dst_path, src_path)
+        os.link(src_path, dst_path)
 
 
 def cleanup_rendered_layers(filepaths_by_layer_id):

--- a/client/ayon_tvpaint/lib.py
+++ b/client/ayon_tvpaint/lib.py
@@ -542,7 +542,8 @@ def copy_render_file(src_path, dst_path):
     try:
         os.link(src_path, dst_path)
     except OSError as exc:
-        if exc.errno != 22:
+        winerror = getattr(exc, "winerror", None)
+        if winerror != 1142:
             raise
         # Exceeded hardlink limit, create new copy of source file to reset
         #   the link limit.

--- a/client/ayon_tvpaint/lib.py
+++ b/client/ayon_tvpaint/lib.py
@@ -544,7 +544,7 @@ def copy_render_file(src_path, dst_path):
     except OSError as exc:
         if exc.errno != 22:
             raise
-        # Exceeded hardlink limit, create new copy of source file and re-start
+        # Exceeded hardlink limit, create new copy of source file to reset
         #   the link limit.
         # NOTE limit on NTFS is 1023 hardlinks
         shutil.copy(src_path, dst_path)

--- a/client/ayon_tvpaint/lib.py
+++ b/client/ayon_tvpaint/lib.py
@@ -535,10 +535,16 @@ def fill_reference_frames(frame_references, filepaths_by_frame):
 
 def copy_render_file(src_path, dst_path):
     """Create copy file of an image."""
-    if hasattr(os, "link"):
-        os.link(src_path, dst_path)
-    else:
+    if not hasattr(os, "link"):
         shutil.copy(src_path, dst_path)
+        return
+
+    try:
+        os.link(src_path, dst_path)
+    except OSError:
+        shutil.copy(src_path, dst_path)
+        os.remove(src_path)
+        shutil.copy(dst_path, src_path)
 
 
 def cleanup_rendered_layers(filepaths_by_layer_id):


### PR DESCRIPTION
## Changelog Description
Reset hardlink if links limit exceeds.

## Additional review information
NTFS has limit of hardlinks to 1023 which can cause that the link can fail. In that case copy the file, remove the source file (to remove the hardlink limit) and copy the destination file back to source file.

## Testing notes:
1. Have a scene with more than 1023 frames.
2. Have a layer with single keyframe on first frame.
3. Publish the file.

Resolves https://github.com/ynput/ayon-tvpaint/issues/75