### PR TITLE
EXR conversion: Fix used variable to cleanup render layer files

### DIFF
--- a/client/ayon_tvpaint/plugins/publish/extract_convert_to_exr.py
+++ b/client/ayon_tvpaint/plugins/publish/extract_convert_to_exr.py
@@ -419,8 +419,8 @@ class ExtractConvertToEXR(pyblish.api.ContextPlugin):
             # Remove the source representation of the render layer
             if self.replace_pngs:
                 layer_repres.remove(src_layer_repre)
-                staging_dir = repre["stagingDir"]
-                filenames = repre["files"]
+                staging_dir = src_layer_repre["stagingDir"]
+                filenames = src_layer_repre["files"]
                 if not isinstance(filenames, list):
                     filenames = [filenames]
                 src_filepaths = [


### PR DESCRIPTION
## Changelog Description
Use correct variable to collect files to cleanup at the end of publishing.

## Additional review information
It used wrong variable to collect files for cleanup of renderlayers in case only EXRs should be kept during publishing.

## Testing notes:
1. Enable to keep only exr.
2. No png files should remain in temp files.

Resolves https://github.com/ynput/ayon-tvpaint/issues/76