### PR TITLE
Composite images: Make sure all layers are available in mappings

### DIFF
--- a/client/ayon_tvpaint/plugins/publish/extract_sequence.py
+++ b/client/ayon_tvpaint/plugins/publish/extract_sequence.py
@@ -18,6 +18,7 @@ from ayon_tvpaint.api.lib import (
     execute_george_through_file,
     get_layers_pre_post_behavior,
     get_layers_exposure_frames,
+    get_layer_pos_filename_template,
 )
 from ayon_tvpaint.lib import (
     calculate_layers_extraction_data,
@@ -340,11 +341,31 @@ class ExtractSequence(pyblish.api.InstancePlugin):
             mark_out
         )
 
+        # Fake transparent output of layers that either don't have exposure
+        #   frames or don't have frames in Mark in/out range.
+        for layer_id, layer in layers_by_id:
+            if layer_id in extraction_data_by_layer_id:
+                continue
+            layer_position = layer["position"]
+            layer_template = get_layer_pos_filename_template(mark_out)
+            filenames_by_frame_index = {}
+            for frame_idx in range(mark_in, mark_out + 1):
+                filenames_by_frame_index[frame_idx] = layer_template.format(
+                    pos=layer_position,
+                    frame=frame_idx
+                )
+
+            frame_references = {
+                frame: mark_in
+                for frame in range(mark_in, mark_out + 1)
+            }
+            extraction_data_by_layer_id[layer_id] = {
+                "frame_references": frame_references,
+                "filenames_by_frame_index": filenames_by_frame_index,
+            }
+
         # Render layers
-        filepaths_by_layer_id = {
-            layer_id: {}
-            for layer_id in layers_by_id
-        }
+        filepaths_by_layer_id = {}
         for layer_id, render_data in extraction_data_by_layer_id.items():
             layer = layers_by_id[layer_id]
             transparency = 1.0

--- a/client/ayon_tvpaint/plugins/publish/extract_sequence.py
+++ b/client/ayon_tvpaint/plugins/publish/extract_sequence.py
@@ -343,9 +343,13 @@ class ExtractSequence(pyblish.api.InstancePlugin):
 
         # Fake transparent output of layers that either don't have exposure
         #   frames or don't have frames in Mark in/out range.
+        transparent_layer_ids = set()
         for layer_id, layer in layers_by_id.items():
             if layer_id in extraction_data_by_layer_id:
                 continue
+
+            transparent_layer_ids.add(layer_id)
+
             layer_position = layer["position"]
             layer_template = get_layer_pos_filename_template(mark_out)
 
@@ -377,6 +381,10 @@ class ExtractSequence(pyblish.api.InstancePlugin):
                 transparency_int = int(execute_george("tv_layerdensity 100"))
                 execute_george(f"tv_layerdensity {transparency_int}")
                 transparency = float(transparency_int) / 100.0
+
+            # Make sure transparent images are transparent
+            if layer_id in transparent_layer_ids:
+                transparency = 0.0
 
             filepaths_by_layer_id[layer_id] = self._render_layer(
                 render_data, layer, output_dir, transparency

--- a/client/ayon_tvpaint/plugins/publish/extract_sequence.py
+++ b/client/ayon_tvpaint/plugins/publish/extract_sequence.py
@@ -341,7 +341,10 @@ class ExtractSequence(pyblish.api.InstancePlugin):
         )
 
         # Render layers
-        filepaths_by_layer_id = {}
+        filepaths_by_layer_id = {
+            layer_id: {}
+            for layer_id in layers_by_id
+        }
         for layer_id, render_data in extraction_data_by_layer_id.items():
             layer = layers_by_id[layer_id]
             transparency = 1.0

--- a/client/ayon_tvpaint/plugins/publish/extract_sequence.py
+++ b/client/ayon_tvpaint/plugins/publish/extract_sequence.py
@@ -343,22 +343,24 @@ class ExtractSequence(pyblish.api.InstancePlugin):
 
         # Fake transparent output of layers that either don't have exposure
         #   frames or don't have frames in Mark in/out range.
-        for layer_id, layer in layers_by_id:
+        for layer_id, layer in layers_by_id.items():
             if layer_id in extraction_data_by_layer_id:
                 continue
             layer_position = layer["position"]
             layer_template = get_layer_pos_filename_template(mark_out)
-            filenames_by_frame_index = {}
-            for frame_idx in range(mark_in, mark_out + 1):
-                filenames_by_frame_index[frame_idx] = layer_template.format(
-                    pos=layer_position,
-                    frame=frame_idx
-                )
 
             frame_references = {
                 frame: mark_in
                 for frame in range(mark_in, mark_out + 1)
             }
+
+            filenames_by_frame_index = {}
+            for frame_idx in frame_references:
+                filenames_by_frame_index[frame_idx] = layer_template.format(
+                    pos=layer_position,
+                    frame=frame_idx
+                )
+
             extraction_data_by_layer_id[layer_id] = {
                 "frame_references": frame_references,
                 "filenames_by_frame_index": filenames_by_frame_index,


### PR DESCRIPTION
## Changelog Description
Make sure all layers are in 'filepaths_by_layer_id'.

## Additional review information
This is fixing a bug, in case layer does not have any visible frame it does not crash because of missing item in layers mapping.